### PR TITLE
Add GitHub Workflow checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,39 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install rust toolchain
+        run: rustup toolchain install --profile minimal
+
+      - name: Add rust components
+        run: rustup component add rustfmt rust-src clippy
+
+      #- name: Check that Cargo.lock is up to date.
+      #  run: cargo update --workspace --locked
+
+      - name: Build
+        run: cargo build
+
+      - name: Clippy
+        run: cargo clippy
+
+      - name: Test
+        run: cargo test
+

--- a/.github/workflows/signed-off.yml
+++ b/.github/workflows/signed-off.yml
@@ -1,0 +1,20 @@
+name: SignedOff
+
+on: [pull_request]
+
+jobs:
+  check:
+    name: Check commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check commits
+        run: |
+          git fetch
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          ${GITHUB_WORKSPACE}/scripts/check-signed-off.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}

--- a/crypto/src/ecc/curve/mod.rs
+++ b/crypto/src/ecc/curve/mod.rs
@@ -428,7 +428,7 @@ impl Curve {
     }
 
     /// Get the `CurveOps` for the curve.
-    pub fn curve_ops(&self) -> Result<CurveOps, CryptoError> {
+    pub fn curve_ops(&self) -> Result<CurveOps<'_>, CryptoError> {
         CurveOps::try_new(self)
     }
 

--- a/crypto/src/ecc/key.rs
+++ b/crypto/src/ecc/key.rs
@@ -125,7 +125,7 @@ pub struct EccPrivateKey {
 
 impl EccPrivateKey {
     /// Get the private scalar.
-    pub fn get_d(&self) -> cmpa::MpBigEndianUIntByteSlice {
+    pub fn get_d(&self) -> cmpa::MpBigEndianUIntByteSlice<'_> {
         cmpa::MpBigEndianUIntByteSlice::from_bytes(&self.d)
     }
 }

--- a/crypto/src/pure_rust/ecc/curve/mod.rs
+++ b/crypto/src/pure_rust/ecc/curve/mod.rs
@@ -52,7 +52,7 @@ impl CurveFieldOps {
 
     /// Get the scalar field's prime.
     #[allow(unused)]
-    pub fn get_p(&self) -> &cmpa::MpBigEndianUIntByteSlice {
+    pub fn get_p(&self) -> &cmpa::MpBigEndianUIntByteSlice<'_> {
         &self.p
     }
 
@@ -101,7 +101,7 @@ impl CurveFieldOps {
     }
 
     /// Get *(Montgomery radix)<sup>2</sup> mod p*.
-    fn get_mg_radix2_mod_p(&self) -> cmpa::MpNativeEndianUIntLimbsSlice {
+    fn get_mg_radix2_mod_p(&self) -> cmpa::MpNativeEndianUIntLimbsSlice<'_> {
         cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_radix2_mod_p)
     }
 
@@ -263,7 +263,7 @@ impl AffinePoint {
     }
 
     /// Access the coordinates in Montgomery form.
-    fn get_mg_coordinates(&self) -> (cmpa::MpNativeEndianUIntLimbsSlice, cmpa::MpNativeEndianUIntLimbsSlice) {
+    fn get_mg_coordinates(&self) -> (cmpa::MpNativeEndianUIntLimbsSlice<'_>, cmpa::MpNativeEndianUIntLimbsSlice<'_>) {
         (
             cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_x),
             cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_y),
@@ -342,9 +342,9 @@ impl ProjectivePoint {
     fn get_mg_coordinates(
         &self,
     ) -> (
-        cmpa::MpNativeEndianUIntLimbsSlice,
-        cmpa::MpNativeEndianUIntLimbsSlice,
-        cmpa::MpNativeEndianUIntLimbsSlice,
+        cmpa::MpNativeEndianUIntLimbsSlice<'_>,
+        cmpa::MpNativeEndianUIntLimbsSlice<'_>,
+        cmpa::MpNativeEndianUIntLimbsSlice<'_>,
     ) {
         (
             cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_x),
@@ -357,9 +357,9 @@ impl ProjectivePoint {
     fn get_mg_coordinates_mut(
         &mut self,
     ) -> (
-        cmpa::MpMutNativeEndianUIntLimbsSlice,
-        cmpa::MpMutNativeEndianUIntLimbsSlice,
-        cmpa::MpMutNativeEndianUIntLimbsSlice,
+        cmpa::MpMutNativeEndianUIntLimbsSlice<'_>,
+        cmpa::MpMutNativeEndianUIntLimbsSlice<'_>,
+        cmpa::MpMutNativeEndianUIntLimbsSlice<'_>,
     ) {
         (
             cmpa::MpMutNativeEndianUIntLimbsSlice::from_limbs(&mut self.mg_x),

--- a/crypto/src/pure_rust/ecc/curve/weierstrass_arithmetic.rs
+++ b/crypto/src/pure_rust/ecc/curve/weierstrass_arithmetic.rs
@@ -73,12 +73,12 @@ impl WeierstrassCurveOps {
     }
 
     /// Get the *a* coefficient in Montgomery form.
-    fn get_mg_a(&self) -> cmpa::MpNativeEndianUIntLimbsSlice {
+    fn get_mg_a(&self) -> cmpa::MpNativeEndianUIntLimbsSlice<'_> {
         cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_a)
     }
 
     /// Get the *b* coefficient in Montgomery form.
-    fn get_mg_b(&self) -> cmpa::MpNativeEndianUIntLimbsSlice {
+    fn get_mg_b(&self) -> cmpa::MpNativeEndianUIntLimbsSlice<'_> {
         cmpa::MpNativeEndianUIntLimbsSlice::from_limbs(&self.mg_b)
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.86.0"

--- a/scripts/check-signed-off.sh
+++ b/scripts/check-signed-off.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# Author: Carlos López <carlos.lopez@suse.com>
+#
+# Simple script to check that a commit has a Signed-off-by trailer and a
+# nonempty commit body.
+
+matches_any() {
+	needle=$1
+	haystack=$2
+
+	while IFS= read -r item; do
+		if [ "$needle" = "$item" ]; then
+			return 0
+		fi
+	done < <(printf '%s\n' "$haystack")
+
+	return 1
+}
+
+# Check that the body for the given commit is not empty
+nonempty_body() {
+	body=$(git show --no-patch --format="%b" "$1" | sed '/^ *$/d')
+	trailers=$(git show --no-patch --format="%(trailers:only)" "$1")
+
+	body_len=$(echo "$body" | wc -l)
+	trailer_len=$(echo "$trailers" | wc -l)
+
+	# If the body is the same length as the trailers it means the body is empty
+	[ "$body_len" = "$trailer_len" ] && return 1
+	return 0
+}
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $0 <start_commit> [<end_commit>]"
+	exit 1
+fi
+
+start=$1
+end=${2:-HEAD}
+
+commits=$(git log --no-merges "${start}".."${end}" --format="%H")
+for c in ${commits[@]}; do
+
+	echo "Checking $c"
+
+	nonempty_body "$c"
+	if [ "$?" != "0" ]; then
+		echo "Message body is empty for commit $c"
+		exit 1
+	fi
+
+	commit_email=$(git show --no-patch --format="%ae" "$c" || exit 1)
+	commit_name=$(git show --no-patch --format="%an" "$c" || exit 1)
+	sign_names=$(git show --no-patch "$c" | sed -nr 's/^[[:space:]]*Signed-off-by: (.*) <(.*)>/\1/p' || exit 1)
+	sign_emails=$(git show --no-patch "$c" | sed -nr 's/^[[:space:]]*Signed-off-by: (.*) <(.*)>/\2/p' || exit 1)
+
+	matches_any "$commit_name" "$sign_names"
+	if [ "$?" != "0" ]; then
+		echo "Author name mismatch on commit $c"
+		echo "    Commit author name: $commit_name"
+		echo "    Signed-off-by name(s):" $sign_names
+		exit 1
+	fi
+
+	matches_any "$commit_email" "$sign_emails"
+	if [ "$?" != "0" ]; then
+		echo "Author email mismatch on commit $c"
+		echo "    Commit author email: $commit_email"
+		echo "    Signed-off-by email(s):" $sign_emails
+		exit 1
+	fi
+
+done
+
+exit 0

--- a/storage/src/fs/cocoonfs/journal/auth_tree_updates.rs
+++ b/storage/src/fs/cocoonfs/journal/auth_tree_updates.rs
@@ -140,11 +140,7 @@ pub fn collect_alloc_bitmap_blocks_for_auth_tree_reconstruction<UI: JournalUpdat
                 alloc_bitmap_file_block_indices.push(alloc_bitmap_file_block_index);
 
                 covered_physical_allocation_blocks_end = layout::PhysicalAllocBlockIndex::from(
-                    (alloc_bitmap_file_block_index + 1)
-                        .checked_mul(
-                            alloc_bitmap_file.get_bitmap_words_per_file_block() << alloc_bitmap::BITMAP_WORD_BITS_LOG2,
-                        )
-                        .unwrap_or(u64::MAX),
+                    (alloc_bitmap_file_block_index + 1).saturating_mul(alloc_bitmap_file.get_bitmap_words_per_file_block() << alloc_bitmap::BITMAP_WORD_BITS_LOG2),
                 );
             }
         }


### PR DESCRIPTION
Enforce some quality checks on commits using GitHub workflow
checks.

This includes:

- Enforce commits to be signed-off and non-empty
- Run cargo build, test, and clippy

Additionally, implement clippy recommendations as far as possible.
Note: clippy warnings are allowed, since not all recommendations
could be implemented, since the affected file is auto-generated.
We should take a look at the generator for that, in a separate PR.
