### PR TITLE
storage: make NvFs::WriteInodeFut::poll() to always return the data

### DIFF
--- a/cocoonfs-cli/src/main.rs
+++ b/cocoonfs-cli/src/main.rs
@@ -902,8 +902,8 @@ fn main() {
             )
             .block_on()
             {
-                Ok((rng, Ok((transaction, _data, Ok(()))))) => (transaction, rng),
-                Ok((_, Ok((_, _, Err(e))))) | Ok((_, Err(e))) | Err(e) => {
+                Ok((rng, (_data, Ok((transaction, Ok(())))))) => (transaction, rng),
+                Ok((_, (_, Ok((_, Err(e)))))) | Ok((_, (_, Err(e)))) | Err(e) => {
                     eprintln!(
                         "error: failed to stage file write at CocoonFS transaction: error={:?}",
                         e

--- a/storage/src/fs/cocoonfs/test/mod.rs
+++ b/storage/src/fs/cocoonfs/test/mod.rs
@@ -380,9 +380,8 @@ fn cocoonfs_test_write_inode_op_helper(
         fs::NvFsFutureAsCoreFuture::<CocoonFs<TestNopSyncTypes, _>, _>::new(fs_instance.clone(), write_inode_fut, rng),
     );
     TestAsyncExecutor::run_to_completion(&executor);
-    let write_inode_result = write_inode_waiter.take().unwrap().unwrap().1;
-    write_inode_result
-        .and_then(|(transaction, _write_inode_data, write_inode_result)| write_inode_result.map(|_| transaction))
+    let write_inode_result = write_inode_waiter.take().unwrap().unwrap().1.1;
+    write_inode_result.and_then(|(transaction, write_inode_result)| write_inode_result.map(|_| transaction))
 }
 
 fn cocoonfs_test_read_inode_op_helper(


### PR DESCRIPTION
The  NvFs::WriteInodeFut is supposed to take ownership of the input data buffer for the duration of its operation and to eventually return it back upon completion. However, right now, it is not expected to always return it back unconditionally -- a stale transaction as indicated by NvFsError::Retry is an example where it would not return the data back.

This is an API misdesign though, because the caller can hardly conduct a retry if it doesn't have the data buffer.

Make NvFs::WriteInodeFut::poll() to always return the input data buffer back upon completion.