### PR TITLE
common-utils: Fix xor_bytes() bug on certain architectures

### DIFF
--- a/utils-common/Cargo.toml
+++ b/utils-common/Cargo.toml
@@ -20,3 +20,6 @@ zeroize = ["dep:zeroize", "cmpa/zeroize"]
 [dependencies]
 cmpa = { version = "0.1.0", default-features = false }
 zeroize = { version = "1.8.1", optional = true, default-features = false, features= ["alloc"] }
+
+[dev-dependencies]
+fastrand = { version = "2.3.0", default-features = false }

--- a/utils-common/src/ct_cmp.rs
+++ b/utils-common/src/ct_cmp.rs
@@ -93,25 +93,30 @@ pub fn ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
 fn test_ct_bytes_eq() {
     use core::mem;
 
-    let mut bytes0 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let mut bytes1 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-        for j in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-            let bytes0 = &mut bytes0[i..i + 32];
-            let bytes1 = &mut bytes1[j..j + 32];
-            bytes0.fill(0xcc);
-            bytes1.fill(0xcc);
+    const LEN: usize = 32;
+    const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
+    let mut bytes0 = [0u8; LEN + EXTRA];
+    let mut bytes1 = [0u8; LEN + EXTRA];
+
+    let mut rng = fastrand::Rng::with_seed(0xdeadbeef);
+
+    for i in 0..EXTRA {
+        for j in 0..EXTRA {
+            let bytes0 = &mut bytes0[i..i + LEN];
+            let bytes1 = &mut bytes1[j..j + LEN];
+            bytes0.fill_with(|| rng.u8(..));
+            bytes1.copy_from_slice(bytes0);
             assert_ne!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
 
-            for k in 0..32 {
-                bytes0.fill(0xcc);
-                bytes1.fill(0xcc);
-                bytes0[k] = 0x77;
+            for k in 0..LEN {
+                bytes0.fill_with(|| rng.u8(..));
+                bytes1.copy_from_slice(bytes0);
+                bytes0[k] = bytes1[k].wrapping_add(1);
                 assert_eq!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
 
-                bytes0.fill(0xcc);
-                bytes1.fill(0xcc);
-                bytes1[k] = 0x77;
+                bytes0.fill_with(|| rng.u8(..));
+                bytes1.copy_from_slice(bytes0);
+                bytes1[k] = bytes0[k].wrapping_add(1);
                 assert_eq!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
             }
         }

--- a/utils-common/src/ct_cmp.rs
+++ b/utils-common/src/ct_cmp.rs
@@ -21,6 +21,10 @@ fn _ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
 /// * `bytes` - The slice to examine.
 pub fn ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
     // Split bytes[] into regions of &[u8], &[LimbType], &[u8].
+    // SAFETY: `LimbType` is an integer type (`u64` or `u32`), so every possible
+    // bit pattern of the source `u8` bytes is a valid `LimbType` value. The
+    // `align_to` method handles alignment by only grouping properly-aligned
+    // interior bytes into the middle `&[LimbType]` slice.
     let (bytes_head, limbs, bytes_tail) = unsafe { bytes.align_to::<cmpa::LimbType>() };
     let mut all_zero = _ct_bytes_all_zero(bytes_head);
     let mut limbs_any_nonzero: cmpa::LimbType = 0;

--- a/utils-common/src/ct_cmp.rs
+++ b/utils-common/src/ct_cmp.rs
@@ -5,7 +5,6 @@
 //! Constant-time comparisons of byte slices.
 
 use cmpa::{self, LimbType};
-use core::mem;
 
 fn _ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
     let mut any_nonzero: cmpa::LimbType = 0;
@@ -35,6 +34,8 @@ pub fn ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
 
 #[test]
 fn test_ct_bytes_all_zero() {
+    use core::mem;
+
     let mut bytes = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
         let bytes = &mut bytes[i..i + 32];
@@ -49,11 +50,14 @@ fn test_ct_bytes_all_zero() {
     }
 }
 
-fn _ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
+fn _ct_bytes_eq<T>(bytes0: &[T], bytes1: &[T]) -> cmpa::LimbChoice
+where
+    T: Copy + Into<LimbType>,
+{
     debug_assert_eq!(bytes0.len(), bytes1.len());
     let mut any_neq: cmpa::LimbType = 0;
-    for pair in bytes0.iter().zip(bytes1.iter()) {
-        any_neq |= (*pair.0 as LimbType) ^ (*pair.1 as LimbType);
+    for (a, b) in bytes0.iter().zip(bytes1.iter()) {
+        any_neq |= Into::<LimbType>::into(*a) ^ Into::<LimbType>::into(*b);
     }
     cmpa::ct_eq_l_l(any_neq, 0)
 }
@@ -68,84 +72,27 @@ pub fn ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
     debug_assert_eq!(bytes0.len(), bytes1.len());
 
     // Split bytes0 and bytes1 into regions of &[u8], &[LimbType], &[u8] each.
+    // SAFETY: `LimbType` is an integer type (`u64` or `u32`), so every possible
+    // bit pattern of the source `u8` bytes is a valid `LimbType` value. The
+    // `align_to_mut`/`align_to` methods handle alignment by only grouping
+    // properly-aligned interior bytes into the middle `&[LimbType]` slice.
     let (bytes0_head, bytes0_limbs, bytes0_tail) = unsafe { bytes0.align_to::<cmpa::LimbType>() };
     let (bytes1_head, bytes1_limbs, bytes1_tail) = unsafe { bytes1.align_to::<cmpa::LimbType>() };
 
-    // Now, bytes0_head.len() is not necessarily equal to bytes1_head.len().
-    // Grab the missing bytes back from the &[LimbType] region as appropriate.
-    // Conditionally swap bytes0 and bytes1 such that bytes0 refers to the one
-    // with the shorter &[u8] head part.
-    let (bytes0_head, bytes0_limbs, bytes0_tail, bytes1_head, bytes1_limbs, bytes1_tail) =
-        if bytes0_head.len() <= bytes1_head.len() {
-            (
-                bytes0_head,
-                bytes0_limbs,
-                bytes0_tail,
-                bytes1_head,
-                bytes1_limbs,
-                bytes1_tail,
-            )
-        } else {
-            (
-                bytes1_head,
-                bytes1_limbs,
-                bytes1_tail,
-                bytes0_head,
-                bytes0_limbs,
-                bytes0_tail,
-            )
-        };
-    debug_assert!(bytes0_head.len() <= bytes1_head.len());
-    if (bytes1_head.len() - bytes0_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-        // The LimbType regions are in no correspondence.
+    if bytes0_head.len() != bytes1_head.len() {
         return _ct_bytes_eq(bytes0, bytes1);
     }
-    let bytes0_head_0 = bytes0_head;
-    // bytes1_head_0 corresponds to bytes0_head_0, bytes1_head_1 to the
-    // head of dst_limbs.
-    let (bytes1_head_0, bytes1_head_1) = bytes1_head.split_at(bytes0_head_0.len());
-    debug_assert_eq!(bytes1_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-    if bytes1_head_1.len() >= mem::size_of_val(bytes0_limbs) {
-        // All of bytes0's LimbType region would get converted back into bytes anyway.
-        return _ct_bytes_eq(bytes0, bytes1);
-    }
-    let (bytes0_limbs_head, bytes0_limbs) =
-        bytes0_limbs.split_at(bytes1_head_1.len() / mem::size_of::<cmpa::LimbType>());
-    let bytes0_head_1 = cmpa::limb_slice_as_bytes(bytes0_limbs_head);
-    debug_assert_eq!(bytes0_head_0.len(), bytes1_head_0.len());
-    debug_assert_eq!(bytes0_head_1.len(), bytes1_head_1.len());
 
-    // Handle the tails. Swap the remaining parts such that bytes0_* refers to the
-    // part with the longer LimbType region.
-    let (bytes0_limbs, bytes0_tail, bytes1_limbs, bytes1_tail) = if bytes1_limbs.len() <= bytes0_limbs.len() {
-        (bytes0_limbs, bytes0_tail, bytes1_limbs, bytes1_tail)
-    } else {
-        (bytes1_limbs, bytes1_tail, bytes0_limbs, bytes0_tail)
-    };
-    debug_assert!(bytes1_limbs.len() <= bytes0_limbs.len());
-    // bytes1_tail_0 corresponds to the tail part of bytes0_limbs,
-    // bytes1_tail_1 to bytes0_tail.
-    let bytes0_tail_1 = bytes0_tail;
-    let (bytes0_limbs, bytes0_limbs_tail) = bytes0_limbs.split_at(bytes1_limbs.len());
-    let bytes0_tail_0 = cmpa::limb_slice_as_bytes(bytes0_limbs_tail);
-    let (bytes1_tail_0, bytes1_tail_1) = bytes1_tail.split_at(bytes0_tail_0.len());
-    debug_assert_eq!(bytes0_tail_0.len(), bytes1_tail_0.len());
-    debug_assert_eq!(bytes0_tail_1.len(), bytes1_tail_1.len());
-
-    let mut all_eq = _ct_bytes_eq(bytes0_head_0, bytes1_head_0);
-    all_eq &= _ct_bytes_eq(bytes0_head_1, bytes1_head_1);
-    let mut any_neq: cmpa::LimbType = 0;
-    for pair in bytes0_limbs.iter().zip(bytes1_limbs.iter()) {
-        any_neq |= pair.0 ^ pair.1;
-    }
-    all_eq &= cmpa::ct_eq_l_l(any_neq, 0);
-    all_eq &= _ct_bytes_eq(bytes0_tail_0, bytes1_tail_0);
-    all_eq &= _ct_bytes_eq(bytes0_tail_1, bytes1_tail_1);
+    let mut all_eq = _ct_bytes_eq(bytes0_head, bytes1_head);
+    all_eq &= _ct_bytes_eq(bytes0_limbs, bytes1_limbs);
+    all_eq &= _ct_bytes_eq(bytes0_tail, bytes1_tail);
     all_eq
 }
 
 #[test]
 fn test_ct_bytes_eq() {
+    use core::mem;
+
     let mut bytes0 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     let mut bytes1 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {

--- a/utils-common/src/ct_cmp.rs
+++ b/utils-common/src/ct_cmp.rs
@@ -5,7 +5,6 @@
 //! Constant-time comparisons of byte slices.
 
 use cmpa::{self, LimbType};
-use core::mem;
 
 fn _ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
     let mut any_nonzero: cmpa::LimbType = 0;
@@ -35,6 +34,8 @@ pub fn ct_bytes_all_zero(bytes: &[u8]) -> cmpa::LimbChoice {
 
 #[test]
 fn test_ct_bytes_all_zero() {
+    use core::mem;
+
     let mut bytes = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
         let bytes = &mut bytes[i..i + 32];
@@ -49,11 +50,14 @@ fn test_ct_bytes_all_zero() {
     }
 }
 
-fn _ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
+fn _ct_bytes_eq<T>(bytes0: &[T], bytes1: &[T]) -> cmpa::LimbChoice
+where
+    T: Copy + Into<LimbType>,
+{
     debug_assert_eq!(bytes0.len(), bytes1.len());
     let mut any_neq: cmpa::LimbType = 0;
-    for pair in bytes0.iter().zip(bytes1.iter()) {
-        any_neq |= (*pair.0 as LimbType) ^ (*pair.1 as LimbType);
+    for (a, b) in bytes0.iter().zip(bytes1.iter()) {
+        any_neq |= Into::<LimbType>::into(*a) ^ Into::<LimbType>::into(*b);
     }
     cmpa::ct_eq_l_l(any_neq, 0)
 }
@@ -68,84 +72,27 @@ pub fn ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
     debug_assert_eq!(bytes0.len(), bytes1.len());
 
     // Split bytes0 and bytes1 into regions of &[u8], &[LimbType], &[u8] each.
+    // SAFETY: `LimbType` is an integer type (`u64` or `u32`), so every possible
+    // bit pattern of the source `u8` bytes is a valid `LimbType` value. The
+    // `align_to` method handles alignment by only grouping properly-aligned
+    // interior bytes into the middle `&[LimbType]` slice.
     let (bytes0_head, bytes0_limbs, bytes0_tail) = unsafe { bytes0.align_to::<cmpa::LimbType>() };
     let (bytes1_head, bytes1_limbs, bytes1_tail) = unsafe { bytes1.align_to::<cmpa::LimbType>() };
 
-    // Now, bytes0_head.len() is not necessarily equal to bytes1_head.len().
-    // Grab the missing bytes back from the &[LimbType] region as appropriate.
-    // Conditionally swap bytes0 and bytes1 such that bytes0 refers to the one
-    // with the shorter &[u8] head part.
-    let (bytes0_head, bytes0_limbs, bytes0_tail, bytes1_head, bytes1_limbs, bytes1_tail) =
-        if bytes0_head.len() <= bytes1_head.len() {
-            (
-                bytes0_head,
-                bytes0_limbs,
-                bytes0_tail,
-                bytes1_head,
-                bytes1_limbs,
-                bytes1_tail,
-            )
-        } else {
-            (
-                bytes1_head,
-                bytes1_limbs,
-                bytes1_tail,
-                bytes0_head,
-                bytes0_limbs,
-                bytes0_tail,
-            )
-        };
-    debug_assert!(bytes0_head.len() <= bytes1_head.len());
-    if (bytes1_head.len() - bytes0_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-        // The LimbType regions are in no correspondence.
+    if bytes0_head.len() != bytes1_head.len() {
         return _ct_bytes_eq(bytes0, bytes1);
     }
-    let bytes0_head_0 = bytes0_head;
-    // bytes1_head_0 corresponds to bytes0_head_0, bytes1_head_1 to the
-    // head of dst_limbs.
-    let (bytes1_head_0, bytes1_head_1) = bytes1_head.split_at(bytes0_head_0.len());
-    debug_assert_eq!(bytes1_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-    if bytes1_head_1.len() >= mem::size_of_val(bytes0_limbs) {
-        // All of bytes0's LimbType region would get converted back into bytes anyway.
-        return _ct_bytes_eq(bytes0, bytes1);
-    }
-    let (bytes0_limbs_head, bytes0_limbs) =
-        bytes0_limbs.split_at(bytes1_head_1.len() / mem::size_of::<cmpa::LimbType>());
-    let bytes0_head_1 = cmpa::limb_slice_as_bytes(bytes0_limbs_head);
-    debug_assert_eq!(bytes0_head_0.len(), bytes1_head_0.len());
-    debug_assert_eq!(bytes0_head_1.len(), bytes1_head_1.len());
 
-    // Handle the tails. Swap the remaining parts such that bytes0_* refers to the
-    // part with the longer LimbType region.
-    let (bytes0_limbs, bytes0_tail, bytes1_limbs, bytes1_tail) = if bytes1_limbs.len() <= bytes0_limbs.len() {
-        (bytes0_limbs, bytes0_tail, bytes1_limbs, bytes1_tail)
-    } else {
-        (bytes1_limbs, bytes1_tail, bytes0_limbs, bytes0_tail)
-    };
-    debug_assert!(bytes1_limbs.len() <= bytes0_limbs.len());
-    // bytes1_tail_0 corresponds to the tail part of bytes0_limbs,
-    // bytes1_tail_1 to bytes0_tail.
-    let bytes0_tail_1 = bytes0_tail;
-    let (bytes0_limbs, bytes0_limbs_tail) = bytes0_limbs.split_at(bytes1_limbs.len());
-    let bytes0_tail_0 = cmpa::limb_slice_as_bytes(bytes0_limbs_tail);
-    let (bytes1_tail_0, bytes1_tail_1) = bytes1_tail.split_at(bytes0_tail_0.len());
-    debug_assert_eq!(bytes0_tail_0.len(), bytes1_tail_0.len());
-    debug_assert_eq!(bytes0_tail_1.len(), bytes1_tail_1.len());
-
-    let mut all_eq = _ct_bytes_eq(bytes0_head_0, bytes1_head_0);
-    all_eq &= _ct_bytes_eq(bytes0_head_1, bytes1_head_1);
-    let mut any_neq: cmpa::LimbType = 0;
-    for pair in bytes0_limbs.iter().zip(bytes1_limbs.iter()) {
-        any_neq |= pair.0 ^ pair.1;
-    }
-    all_eq &= cmpa::ct_eq_l_l(any_neq, 0);
-    all_eq &= _ct_bytes_eq(bytes0_tail_0, bytes1_tail_0);
-    all_eq &= _ct_bytes_eq(bytes0_tail_1, bytes1_tail_1);
+    let mut all_eq = _ct_bytes_eq(bytes0_head, bytes1_head);
+    all_eq &= _ct_bytes_eq(bytes0_limbs, bytes1_limbs);
+    all_eq &= _ct_bytes_eq(bytes0_tail, bytes1_tail);
     all_eq
 }
 
 #[test]
 fn test_ct_bytes_eq() {
+    use core::mem;
+
     const LEN: usize = 32;
     const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
     let mut bytes0 = [0u8; LEN + EXTRA];

--- a/utils-common/src/ct_cmp.rs
+++ b/utils-common/src/ct_cmp.rs
@@ -146,25 +146,30 @@ pub fn ct_bytes_eq(bytes0: &[u8], bytes1: &[u8]) -> cmpa::LimbChoice {
 
 #[test]
 fn test_ct_bytes_eq() {
-    let mut bytes0 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let mut bytes1 = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-        for j in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-            let bytes0 = &mut bytes0[i..i + 32];
-            let bytes1 = &mut bytes1[j..j + 32];
-            bytes0.fill(0xcc);
-            bytes1.fill(0xcc);
+    const LEN: usize = 32;
+    const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
+    let mut bytes0 = [0u8; LEN + EXTRA];
+    let mut bytes1 = [0u8; LEN + EXTRA];
+
+    let mut rng = crate::test_utils::Prng::new();
+
+    for i in 0..EXTRA {
+        for j in 0..EXTRA {
+            let bytes0 = &mut bytes0[i..i + LEN];
+            let bytes1 = &mut bytes1[j..j + LEN];
+            bytes0.fill_with(|| rng.get());
+            bytes1.copy_from_slice(bytes0);
             assert_ne!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
 
-            for k in 0..32 {
-                bytes0.fill(0xcc);
-                bytes1.fill(0xcc);
-                bytes0[k] = 0x77;
+            for k in 0..LEN {
+                bytes0.fill_with(|| rng.get());
+                bytes1.copy_from_slice(bytes0);
+                bytes0[k] = bytes1[k].wrapping_add(1);
                 assert_eq!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
 
-                bytes0.fill(0xcc);
-                bytes1.fill(0xcc);
-                bytes1[k] = 0x77;
+                bytes0.fill_with(|| rng.get());
+                bytes1.copy_from_slice(bytes0);
+                bytes1[k] = bytes0[k].wrapping_add(1);
                 assert_eq!(ct_bytes_eq(bytes0, bytes1).unwrap(), 0);
             }
         }

--- a/utils-common/src/lib.rs
+++ b/utils-common/src/lib.rs
@@ -13,3 +13,6 @@ pub mod io_slices;
 pub mod murmurhash3;
 pub mod xor;
 pub mod zeroize;
+
+#[cfg(test)]
+mod test_utils;

--- a/utils-common/src/test_utils.rs
+++ b/utils-common/src/test_utils.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+//
+// Simple xorshift32 PRNG — no std required.
+// https://en.wikipedia.org/wiki/Xorshift
+
+pub struct Prng {
+    state: u32,
+}
+
+impl Prng {
+    pub fn new() -> Self {
+        Self { state: 0xdeadbeef }
+    }
+
+    pub fn get(&mut self) -> u8 {
+        self.state ^= self.state << 13;
+        self.state ^= self.state >> 17;
+        self.state ^= self.state << 5;
+        self.state as u8
+    }
+}

--- a/utils-common/src/xor.rs
+++ b/utils-common/src/xor.rs
@@ -53,16 +53,29 @@ pub fn xor_bytes(dst: &mut [u8], mask: &[u8]) {
 fn test_xor_bytes() {
     use core::mem;
 
-    let mut dst = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let mask = [0x77u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let expected = [0xbbu8; 32];
-    for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-        for j in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-            let dst = &mut dst[i..i + 32];
-            dst.fill(0xccu8);
-            let mask = &mask[j..j + 32];
-            xor_bytes(dst, mask);
-            assert_eq!(dst, expected);
+    const LEN: usize = 32;
+    const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
+    let mut dst = [0u8; LEN + EXTRA];
+    let mut mask = [0u8; LEN + EXTRA];
+    let mut expected = [0u8; LEN];
+
+    let mut rng = fastrand::Rng::with_seed(0xdeadbeef);
+
+    for i in 0..EXTRA {
+        for j in 0..EXTRA {
+            dst.fill_with(|| rng.u8(..));
+            mask.fill_with(|| rng.u8(..));
+
+            let dst_slice = &mut dst[i..i + LEN];
+            let mask_slice = &mask[j..j + LEN];
+
+            // Compute expected result byte-by-byte.
+            for k in 0..LEN {
+                expected[k] = dst_slice[k] ^ mask_slice[k];
+            }
+
+            xor_bytes(dst_slice, mask_slice);
+            assert_eq!(dst_slice, expected);
         }
     }
 }

--- a/utils-common/src/xor.rs
+++ b/utils-common/src/xor.rs
@@ -5,13 +5,15 @@
 //! Xor two byte slices.
 
 use cmpa;
-use core::mem;
 
-fn _xor_bytes(dst: &mut [u8], mask: &[u8]) {
+fn _xor_slice<T>(dst: &mut [T], mask: &[T])
+where
+    T: core::ops::BitXorAssign + Copy,
+{
     debug_assert_eq!(dst.len(), mask.len());
 
-    for i in dst.iter_mut().zip(mask.iter()) {
-        *i.0 ^= i.1;
+    for (d, m) in dst.iter_mut().zip(mask.iter()) {
+        *d ^= *m;
     }
 }
 
@@ -21,128 +23,36 @@ fn _xor_bytes(dst: &mut [u8], mask: &[u8]) {
 ///
 /// # Arguments:
 ///
-/// * `dst` - First operand and destination..
-/// * `src` - Second operand.
+/// * `dst` - First operand and destination.
+/// * `mask` - Second operand.
 pub fn xor_bytes(dst: &mut [u8], mask: &[u8]) {
     debug_assert_eq!(dst.len(), mask.len());
 
     // Split dst and mask into regions of &[u8], &[LimbType], &[u8] each.
+    // SAFETY: `LimbType` is an integer type (`u64` or `u32`), so every possible
+    // bit pattern of the source `u8` bytes is a valid `LimbType` value. The
+    // `align_to_mut`/`align_to` methods handle alignment by only grouping
+    // properly-aligned interior bytes into the middle `&[LimbType]` slice.
     let (dst_bytes_head, dst_limbs, dst_bytes_tail) = unsafe { dst.align_to_mut::<cmpa::LimbType>() };
     let (mask_bytes_head, mask_limbs, mask_bytes_tail) = unsafe { mask.align_to::<cmpa::LimbType>() };
 
-    // Now, dst_bytes_head.len() is not necessarily equal to mask_bytes_head.len().
-    // Grab the missing bytes back from the &[LimbType] region as appropriate
-    let (dst_bytes_head_0, dst_bytes_head_1, dst_limbs, mask_bytes_head_0, mask_bytes_head_1, mask_limbs) =
-        if dst_bytes_head.len() <= mask_bytes_head.len() {
-            if (mask_bytes_head.len() - dst_bytes_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-                // The LimbType regions are in no correspondence.
-                _xor_bytes(dst, mask);
-                return;
-            }
-
-            let dst_bytes_head_0 = dst_bytes_head;
-            // mask_bytes_head_0 corresponds to dst_bytes_head_0, mask_bytes_head_1 to the
-            // head of dst_limbs.
-            let (mask_bytes_head_0, mask_bytes_head_1) = mask_bytes_head.split_at(dst_bytes_head_0.len());
-            debug_assert_eq!(mask_bytes_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-            if mask_bytes_head_1.len() >= mem::size_of_val(dst_limbs) {
-                // All of dst's LimbType region would get converted back into bytes anyway.
-                _xor_bytes(dst, mask);
-                return;
-            }
-            let (dst_limbs_head, dst_limbs) =
-                dst_limbs.split_at_mut(mask_bytes_head_1.len() / mem::size_of::<cmpa::LimbType>());
-            let dst_bytes_head_1 = cmpa::limb_slice_as_bytes_mut(dst_limbs_head);
-            debug_assert_eq!(dst_bytes_head_1.len(), mask_bytes_head_1.len());
-
-            (
-                dst_bytes_head_0,
-                dst_bytes_head_1,
-                dst_limbs,
-                mask_bytes_head_0,
-                mask_bytes_head_1,
-                mask_limbs,
-            )
-        } else {
-            if (dst_bytes_head.len() - mask_bytes_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-                // The LimbType regions are in no correspondence.
-                _xor_bytes(dst, mask);
-                return;
-            }
-
-            let mask_bytes_head_0 = mask_bytes_head;
-            // dst_bytes_head_0 corresponds to mask_bytes_head_0, dst_bytes_head_1 to the
-            // head of mask_limbs.
-            let (dst_bytes_head_0, dst_bytes_head_1) = dst_bytes_head.split_at_mut(mask_bytes_head_0.len());
-            debug_assert_eq!(dst_bytes_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-            if dst_bytes_head_1.len() >= mem::size_of_val(mask_limbs) {
-                // All of mask's LimbType region would get converted back into bytes anyway.
-                _xor_bytes(dst, mask);
-                return;
-            }
-            let (mask_limbs_head, mask_limbs) =
-                mask_limbs.split_at(dst_bytes_head_1.len() / mem::size_of::<cmpa::LimbType>());
-            let mask_bytes_head_1 = cmpa::limb_slice_as_bytes(mask_limbs_head);
-            debug_assert_eq!(mask_bytes_head_1.len(), dst_bytes_head_1.len());
-
-            (
-                dst_bytes_head_0,
-                dst_bytes_head_1,
-                dst_limbs,
-                mask_bytes_head_0,
-                mask_bytes_head_1,
-                mask_limbs,
-            )
-        };
-    debug_assert_eq!(dst_bytes_head_0.len(), mask_bytes_head_0.len());
-    debug_assert_eq!(dst_bytes_head_1.len(), mask_bytes_head_1.len());
-
-    let (dst_limbs, dst_bytes_tail_0, dst_bytes_tail_1, mask_limbs, mask_bytes_tail_0, mask_bytes_tail_1) =
-        if mask_limbs.len() <= dst_limbs.len() {
-            // mask_bytes_tail_0 corresponds to the tail part of dst_limbs,
-            // mask_bytes_tail_1 to dst_bytes_tail.
-            let dst_bytes_tail_1 = dst_bytes_tail;
-            let (dst_limbs, dst_limbs_tail) = dst_limbs.split_at_mut(mask_limbs.len());
-            let dst_bytes_tail_0 = cmpa::limb_slice_as_bytes_mut(dst_limbs_tail);
-            let (mask_bytes_tail_0, mask_bytes_tail_1) = mask_bytes_tail.split_at(dst_bytes_tail_0.len());
-            (
-                dst_limbs,
-                dst_bytes_tail_0,
-                dst_bytes_tail_1,
-                mask_limbs,
-                mask_bytes_tail_0,
-                mask_bytes_tail_1,
-            )
-        } else {
-            // dst_bytes_tail_0 corresponds to the tail part of mask_limbs,
-            // dst_bytes_tail_1 to mask_bytes_tail.
-            let mask_bytes_tail_1 = mask_bytes_tail;
-            let (mask_limbs, mask_limbs_tail) = mask_limbs.split_at(mask_limbs.len());
-            let mask_bytes_tail_0 = cmpa::limb_slice_as_bytes(mask_limbs_tail);
-            let (dst_bytes_tail_0, dst_bytes_tail_1) = dst_bytes_tail.split_at_mut(mask_bytes_tail_0.len());
-            (
-                dst_limbs,
-                dst_bytes_tail_0,
-                dst_bytes_tail_1,
-                mask_limbs,
-                mask_bytes_tail_0,
-                mask_bytes_tail_1,
-            )
-        };
-    debug_assert_eq!(dst_bytes_tail_0.len(), mask_bytes_tail_0.len());
-    debug_assert_eq!(dst_bytes_tail_1.len(), mask_bytes_tail_1.len());
-
-    _xor_bytes(dst_bytes_head_0, mask_bytes_head_0);
-    _xor_bytes(dst_bytes_head_1, mask_bytes_head_1);
-    for i in dst_limbs.iter_mut().zip(mask_limbs.iter()) {
-        *i.0 ^= i.1;
+    if dst_bytes_head.len() != mask_bytes_head.len() {
+        _xor_slice(dst, mask);
+        return;
     }
-    _xor_bytes(dst_bytes_tail_0, mask_bytes_tail_0);
-    _xor_bytes(dst_bytes_tail_1, mask_bytes_tail_1);
+
+    debug_assert_eq!(dst_limbs.len(), mask_limbs.len());
+    debug_assert_eq!(dst_bytes_tail.len(), mask_bytes_tail.len());
+
+    _xor_slice(dst_bytes_head, mask_bytes_head);
+    _xor_slice(dst_limbs, mask_limbs);
+    _xor_slice(dst_bytes_tail, mask_bytes_tail);
 }
 
 #[test]
 fn test_xor_bytes() {
+    use core::mem;
+
     let mut dst = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     let mask = [0x77u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
     let expected = [0xbbu8; 32];

--- a/utils-common/src/xor.rs
+++ b/utils-common/src/xor.rs
@@ -143,16 +143,29 @@ pub fn xor_bytes(dst: &mut [u8], mask: &[u8]) {
 
 #[test]
 fn test_xor_bytes() {
-    let mut dst = [0u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let mask = [0x77u8; 32 + mem::size_of::<cmpa::LimbType>() - 1];
-    let expected = [0xbbu8; 32];
-    for i in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-        for j in 0..mem::size_of::<cmpa::LimbType>() - 1 {
-            let dst = &mut dst[i..i + 32];
-            dst.fill(0xccu8);
-            let mask = &mask[j..j + 32];
-            xor_bytes(dst, mask);
-            assert_eq!(dst, expected);
+    const LEN: usize = 32;
+    const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
+    let mut dst = [0u8; LEN + EXTRA];
+    let mut mask = [0u8; LEN + EXTRA];
+    let mut expected = [0u8; LEN];
+
+    let mut rng = crate::test_utils::Prng::new();
+
+    for i in 0..EXTRA {
+        for j in 0..EXTRA {
+            dst.fill_with(|| rng.get());
+            mask.fill_with(|| rng.get());
+
+            let dst_slice = &mut dst[i..i + LEN];
+            let mask_slice = &mask[j..j + LEN];
+
+            // Compute expected result byte-by-byte.
+            for k in 0..LEN {
+                expected[k] = dst_slice[k] ^ mask_slice[k];
+            }
+
+            xor_bytes(dst_slice, mask_slice);
+            assert_eq!(dst_slice, expected);
         }
     }
 }

--- a/utils-common/src/xor.rs
+++ b/utils-common/src/xor.rs
@@ -5,13 +5,15 @@
 //! Xor two byte slices.
 
 use cmpa;
-use core::mem;
 
-fn _xor_bytes(dst: &mut [u8], mask: &[u8]) {
+fn _xor_slice<T>(dst: &mut [T], mask: &[T])
+where
+    T: core::ops::BitXorAssign + Copy,
+{
     debug_assert_eq!(dst.len(), mask.len());
 
-    for i in dst.iter_mut().zip(mask.iter()) {
-        *i.0 ^= i.1;
+    for (d, m) in dst.iter_mut().zip(mask.iter()) {
+        *d ^= *m;
     }
 }
 
@@ -21,128 +23,36 @@ fn _xor_bytes(dst: &mut [u8], mask: &[u8]) {
 ///
 /// # Arguments:
 ///
-/// * `dst` - First operand and destination..
-/// * `src` - Second operand.
+/// * `dst` - First operand and destination.
+/// * `mask` - Second operand.
 pub fn xor_bytes(dst: &mut [u8], mask: &[u8]) {
     debug_assert_eq!(dst.len(), mask.len());
 
     // Split dst and mask into regions of &[u8], &[LimbType], &[u8] each.
+    // SAFETY: `LimbType` is an integer type (`u64` or `u32`), so every possible
+    // bit pattern of the source `u8` bytes is a valid `LimbType` value. The
+    // `align_to_mut`/`align_to` methods handle alignment by only grouping
+    // properly-aligned interior bytes into the middle `&[LimbType]` slice.
     let (dst_bytes_head, dst_limbs, dst_bytes_tail) = unsafe { dst.align_to_mut::<cmpa::LimbType>() };
     let (mask_bytes_head, mask_limbs, mask_bytes_tail) = unsafe { mask.align_to::<cmpa::LimbType>() };
 
-    // Now, dst_bytes_head.len() is not necessarily equal to mask_bytes_head.len().
-    // Grab the missing bytes back from the &[LimbType] region as appropriate
-    let (dst_bytes_head_0, dst_bytes_head_1, dst_limbs, mask_bytes_head_0, mask_bytes_head_1, mask_limbs) =
-        if dst_bytes_head.len() <= mask_bytes_head.len() {
-            if (mask_bytes_head.len() - dst_bytes_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-                // The LimbType regions are in no correspondence.
-                _xor_bytes(dst, mask);
-                return;
-            }
-
-            let dst_bytes_head_0 = dst_bytes_head;
-            // mask_bytes_head_0 corresponds to dst_bytes_head_0, mask_bytes_head_1 to the
-            // head of dst_limbs.
-            let (mask_bytes_head_0, mask_bytes_head_1) = mask_bytes_head.split_at(dst_bytes_head_0.len());
-            debug_assert_eq!(mask_bytes_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-            if mask_bytes_head_1.len() >= mem::size_of_val(dst_limbs) {
-                // All of dst's LimbType region would get converted back into bytes anyway.
-                _xor_bytes(dst, mask);
-                return;
-            }
-            let (dst_limbs_head, dst_limbs) =
-                dst_limbs.split_at_mut(mask_bytes_head_1.len() / mem::size_of::<cmpa::LimbType>());
-            let dst_bytes_head_1 = cmpa::limb_slice_as_bytes_mut(dst_limbs_head);
-            debug_assert_eq!(dst_bytes_head_1.len(), mask_bytes_head_1.len());
-
-            (
-                dst_bytes_head_0,
-                dst_bytes_head_1,
-                dst_limbs,
-                mask_bytes_head_0,
-                mask_bytes_head_1,
-                mask_limbs,
-            )
-        } else {
-            if (dst_bytes_head.len() - mask_bytes_head.len()) % mem::size_of::<cmpa::LimbType>() != 0 {
-                // The LimbType regions are in no correspondence.
-                _xor_bytes(dst, mask);
-                return;
-            }
-
-            let mask_bytes_head_0 = mask_bytes_head;
-            // dst_bytes_head_0 corresponds to mask_bytes_head_0, dst_bytes_head_1 to the
-            // head of mask_limbs.
-            let (dst_bytes_head_0, dst_bytes_head_1) = dst_bytes_head.split_at_mut(mask_bytes_head_0.len());
-            debug_assert_eq!(dst_bytes_head_1.len() % mem::size_of::<cmpa::LimbType>(), 0);
-            if dst_bytes_head_1.len() >= mem::size_of_val(mask_limbs) {
-                // All of mask's LimbType region would get converted back into bytes anyway.
-                _xor_bytes(dst, mask);
-                return;
-            }
-            let (mask_limbs_head, mask_limbs) =
-                mask_limbs.split_at(dst_bytes_head_1.len() / mem::size_of::<cmpa::LimbType>());
-            let mask_bytes_head_1 = cmpa::limb_slice_as_bytes(mask_limbs_head);
-            debug_assert_eq!(mask_bytes_head_1.len(), dst_bytes_head_1.len());
-
-            (
-                dst_bytes_head_0,
-                dst_bytes_head_1,
-                dst_limbs,
-                mask_bytes_head_0,
-                mask_bytes_head_1,
-                mask_limbs,
-            )
-        };
-    debug_assert_eq!(dst_bytes_head_0.len(), mask_bytes_head_0.len());
-    debug_assert_eq!(dst_bytes_head_1.len(), mask_bytes_head_1.len());
-
-    let (dst_limbs, dst_bytes_tail_0, dst_bytes_tail_1, mask_limbs, mask_bytes_tail_0, mask_bytes_tail_1) =
-        if mask_limbs.len() <= dst_limbs.len() {
-            // mask_bytes_tail_0 corresponds to the tail part of dst_limbs,
-            // mask_bytes_tail_1 to dst_bytes_tail.
-            let dst_bytes_tail_1 = dst_bytes_tail;
-            let (dst_limbs, dst_limbs_tail) = dst_limbs.split_at_mut(mask_limbs.len());
-            let dst_bytes_tail_0 = cmpa::limb_slice_as_bytes_mut(dst_limbs_tail);
-            let (mask_bytes_tail_0, mask_bytes_tail_1) = mask_bytes_tail.split_at(dst_bytes_tail_0.len());
-            (
-                dst_limbs,
-                dst_bytes_tail_0,
-                dst_bytes_tail_1,
-                mask_limbs,
-                mask_bytes_tail_0,
-                mask_bytes_tail_1,
-            )
-        } else {
-            // dst_bytes_tail_0 corresponds to the tail part of mask_limbs,
-            // dst_bytes_tail_1 to mask_bytes_tail.
-            let mask_bytes_tail_1 = mask_bytes_tail;
-            let (mask_limbs, mask_limbs_tail) = mask_limbs.split_at(mask_limbs.len());
-            let mask_bytes_tail_0 = cmpa::limb_slice_as_bytes(mask_limbs_tail);
-            let (dst_bytes_tail_0, dst_bytes_tail_1) = dst_bytes_tail.split_at_mut(mask_bytes_tail_0.len());
-            (
-                dst_limbs,
-                dst_bytes_tail_0,
-                dst_bytes_tail_1,
-                mask_limbs,
-                mask_bytes_tail_0,
-                mask_bytes_tail_1,
-            )
-        };
-    debug_assert_eq!(dst_bytes_tail_0.len(), mask_bytes_tail_0.len());
-    debug_assert_eq!(dst_bytes_tail_1.len(), mask_bytes_tail_1.len());
-
-    _xor_bytes(dst_bytes_head_0, mask_bytes_head_0);
-    _xor_bytes(dst_bytes_head_1, mask_bytes_head_1);
-    for i in dst_limbs.iter_mut().zip(mask_limbs.iter()) {
-        *i.0 ^= i.1;
+    if dst_bytes_head.len() != mask_bytes_head.len() {
+        _xor_slice(dst, mask);
+        return;
     }
-    _xor_bytes(dst_bytes_tail_0, mask_bytes_tail_0);
-    _xor_bytes(dst_bytes_tail_1, mask_bytes_tail_1);
+
+    debug_assert_eq!(dst_limbs.len(), mask_limbs.len());
+    debug_assert_eq!(dst_bytes_tail.len(), mask_bytes_tail.len());
+
+    _xor_slice(dst_bytes_head, mask_bytes_head);
+    _xor_slice(dst_limbs, mask_limbs);
+    _xor_slice(dst_bytes_tail, mask_bytes_tail);
 }
 
 #[test]
 fn test_xor_bytes() {
+    use core::mem;
+
     const LEN: usize = 32;
     const EXTRA: usize = mem::size_of::<cmpa::LimbType>() - 1;
     let mut dst = [0u8; LEN + EXTRA];


### PR DESCRIPTION
Splitting `mask_limbs` at its own length will always result in the first
part containing everything and the other one nothing.
It should be split at `dst_limbs.len()` to bing both arrays to the same
size.

This code is never used on X86_86 since size and alignment of
LimbType (u64) are both 8 bytes.

To tigger the bug, one needs to run on an architecture where align != size,
for example 32-bit x86.
