### PR TITLE
Cocoonfs-cli: Fix doc warnings

### DIFF
--- a/cocoonfs-cli/src/std_file_nvblkdev.rs
+++ b/cocoonfs-cli/src/std_file_nvblkdev.rs
@@ -36,7 +36,7 @@ struct StdFileNvBlkDevInner {
     /// failed state.
     ///
     /// The failed state is typically entered once a query for
-    /// [`volume_file`](Self::volume_size) fails, and the value in
+    /// [`volume_file`](Self::volume_file) fails, and the value in
     /// [`io_blocks`](Self::io_blocks) has therefore become stale.
     failed: bool,
 }

--- a/cocoonfs-cli/src/std_sync_types.rs
+++ b/cocoonfs-cli/src/std_sync_types.rs
@@ -9,8 +9,8 @@ use crate::utils_async::sync_types;
 use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{convert, marker};
 
-/// [`Lock`](sync_types::SyncTypes:::Lock) trait implementation built on Rust
-/// `std` [`Mutex`](std::sync::Mutex).
+/// [`Lock`](sync_types::SyncTypes::Lock) trait implementation built on Rust
+/// `std` [`Mutex`].
 pub struct StdLock<T: marker::Send> {
     mtx: Mutex<T>,
 }
@@ -38,8 +38,8 @@ impl<T: marker::Send> convert::From<T> for StdLock<T> {
     }
 }
 
-/// [`RwLock`](sync_types::SyncTypes:::Lock) trait implementation built on Rust
-/// `std` [`RwLock`](std::sync::rwLock).
+/// [`RwLock`](sync_types::SyncTypes::Lock) trait implementation built on Rust
+/// `std` [`RwLock`].
 pub struct StdRwLock<T: marker::Send + marker::Sync> {
     rwlock: RwLock<T>,
 }


### PR DESCRIPTION
Fix some doc warnings in coonfs-cli.
