### PR TITLE
Rename WalkableIoSlicesIter::all_alinged_to()

### DIFF
--- a/crypto/src/io_slices.rs
+++ b/crypto/src/io_slices.rs
@@ -174,8 +174,8 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a> for EmptyCryptoIoSlices {
         self.iter.total_len()
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        self.iter.all_aligned_to(alignment)
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        self.iter.all_lengths_multiple_of(alignment)
     }
 }
 

--- a/crypto/src/kdf/tcg_tpm2_kdf_a.rs
+++ b/crypto/src/kdf/tcg_tpm2_kdf_a.rs
@@ -185,8 +185,8 @@ impl<'a> Kdf for TcgTpm2KdfA<'a> {
         }
 
         // The block scratch buf will only be needed if any of the output slices'
-        // lengths doesn't align with the HMAC block length.
-        let block_scratch_buf_len = if !output.all_aligned_to(self.block_len)? {
+        // lengths isn't a multiple of the HMAC block length.
+        let block_scratch_buf_len = if !output.all_lengths_multiple_of(self.block_len)? {
             self.block_len
         } else {
             0

--- a/crypto/src/kdf/tcg_tpm2_kdf_e.rs
+++ b/crypto/src/kdf/tcg_tpm2_kdf_e.rs
@@ -173,8 +173,8 @@ impl<'a> Kdf for TcgTpm2KdfE<'a> {
         }
 
         // The block scratch buf will only be needed if any of the output slices'
-        // lengths doesn't align with the Hash block length.
-        let block_scratch_buf_len = if !output.all_aligned_to(self.block_len)? {
+        // lengths isn't a multiple of the Hash block length.
+        let block_scratch_buf_len = if !output.all_lengths_multiple_of(self.block_len)? {
             self.block_len
         } else {
             0

--- a/storage/src/fs/cocoonfs/transaction/auth_tree_data_blocks_update_states.rs
+++ b/storage/src/fs/cocoonfs/transaction/auth_tree_data_blocks_update_states.rs
@@ -4574,7 +4574,7 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
         Ok(())
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() && alignment <= (1usize << (self.allocation_block_size_128b_log2 as u32 + 7)) {
             // All Allocation Blocks are aligned. Check the head.
             Ok(self
@@ -4583,19 +4583,19 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
                 .map(|slice| slice.len() & (alignment - 1) == 0)
                 .unwrap_or(true))
         } else {
-            let mut all_aligned = true;
+            let mut all_multiple_of = true;
             if alignment.is_pow2() {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() & (alignment - 1) == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                    all_multiple_of
                 })?;
             } else {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() % alignment == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() % alignment == 0;
+                    all_multiple_of
                 })?;
             }
-            Ok(all_aligned)
+            Ok(all_multiple_of)
         }
     }
 }
@@ -4728,7 +4728,7 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
         Ok(())
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() && alignment <= (1usize << (self.allocation_block_size_128b_log2 as u32 + 7)) {
             // All Allocation Blocks are aligned. Check the head.
             Ok(self
@@ -4737,19 +4737,19 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
                 .map(|slice| slice.len() & (alignment - 1) == 0)
                 .unwrap_or(true))
         } else {
-            let mut all_aligned = true;
+            let mut all_multiple_of = true;
             if alignment.is_pow2() {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() & (alignment - 1) == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                    all_multiple_of
                 })?;
             } else {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() % alignment == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() % alignment == 0;
+                    all_multiple_of
                 })?;
             }
-            Ok(all_aligned)
+            Ok(all_multiple_of)
         }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -546,20 +546,20 @@ pub trait WalkableIoSlicesIter<'a>: IoSlicesIter<'a> {
     ///
     /// * [`BackendIteratorError`](IoSlicesIterCommon::BackendIteratorError) -
     ///   Error specific to the trait implementation.
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        let mut all_aligned = true;
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        let mut all_multiple_of = true;
         if alignment.is_pow2() {
             self.for_each(&mut |slice| {
-                all_aligned &= slice.len() & (alignment - 1) == 0;
-                all_aligned
+                all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                all_multiple_of
             })?;
         } else {
             self.for_each(&mut |slice| {
-                all_aligned &= slice.len() % alignment == 0;
-                all_aligned
+                all_multiple_of &= slice.len() % alignment == 0;
+                all_multiple_of
             })?;
         }
-        Ok(all_aligned)
+        Ok(all_multiple_of)
     }
 }
 
@@ -1908,7 +1908,7 @@ impl<'a> WalkableIoSlicesIter<'a> for EmptyIoSlices {
         Ok(0)
     }
 
-    fn all_aligned_to(&self, _alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, _alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         Ok(true)
     }
 }
@@ -2025,8 +2025,8 @@ where
         self.iter.total_len().map_err(|e| (self.f)(e))
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        self.iter.all_aligned_to(alignment).map_err(|e| (self.f)(e))
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        self.iter.all_lengths_multiple_of(alignment).map_err(|e| (self.f)(e))
     }
 }
 
@@ -2138,8 +2138,8 @@ impl<'a, 'b: 'a, I: ?Sized + WalkableIoSlicesIter<'b>> WalkableIoSlicesIter<'a>
         (*self.iter).total_len()
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        (*self.iter).all_aligned_to(alignment)
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        (*self.iter).all_lengths_multiple_of(alignment)
     }
 }
 
@@ -2499,17 +2499,17 @@ where
             + self.iter1.as_ref().map(|iter1| iter1.total_len()).unwrap_or(Ok(0))?)
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         Ok(self
             .iter0
             .as_ref()
-            .map(|iter0| iter0.all_aligned_to(alignment))
+            .map(|iter0| iter0.all_lengths_multiple_of(alignment))
             .transpose()?
             .unwrap_or(true)
             && self
                 .iter1
                 .as_ref()
-                .map(|iter1| iter1.all_aligned_to(alignment))
+                .map(|iter1| iter1.all_lengths_multiple_of(alignment))
                 .transpose()?
                 .unwrap_or(true))
     }
@@ -2612,7 +2612,7 @@ impl<'a> WalkableIoSlicesIter<'a> for ZeroFilledIoSlices {
         Ok(self.remaining)
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() {
             Ok(self.remaining & (alignment - 1) == 0)
         } else {


### PR DESCRIPTION
`WalkableIoSlicesIter::all_alinged_to()` checks that all sub-slices have a length which
is a multiple of the given value. I find that name confusing, since "alignment" usually refers to the
start address of an object and not its size.

Rename it to `all_lengths_multiple_of(n)`.

Closes #13
