### PR TITLE
boringssl: Add missing C++ lib

### DIFF
--- a/bssl-bare-sys-target-integration/build.rs
+++ b/bssl-bare-sys-target-integration/build.rs
@@ -13,4 +13,10 @@ fn main() {
 
     // Set the CMAKE_SYSTEM_NAME for embedded/standalone builds
     // println!("cargo::metadata=CMAKE_SYSTEM_NAME=Generic");
+
+    // BoringSSL contains C++ code. This default integration stub targets a
+    // regular host environment, so link libstdc++. Embedded projects should
+    // replace this crate (via Cargo's [patch] mechanism) and provide
+    // whatever C++ runtime is appropriate for their environment.
+    println!("cargo::rustc-link-lib=stdc++");
 }

--- a/bssl-bare-sys-target-integration/build.rs
+++ b/bssl-bare-sys-target-integration/build.rs
@@ -10,4 +10,7 @@ fn main() {
     // println!("cargo::metadata=CXXFLAGS=");
     // println!("cargo::metadata=LINK_SEARCH={}", ...);
     // println!("cargo::metadata=LINK_LIB={}", ...);
+
+    // Set the CMAKE_SYSTEM_NAME for embedded/standalone builds
+    // println!("cargo::metadata=CMAKE_SYSTEM_NAME=Generic");
 }

--- a/bssl-bare-sys/Cargo.toml
+++ b/bssl-bare-sys/Cargo.toml
@@ -103,10 +103,9 @@ exclude = [
 [lib]
 
 [features]
-target-integration = ["dep:cocoon-tpm-bssl-bare-sys-target-integration"]
 
 [dependencies]
-cocoon-tpm-bssl-bare-sys-target-integration = { version = "0.1.1", optional = true }
+cocoon-tpm-bssl-bare-sys-target-integration = { version = "0.1.1" }
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/bssl-bare-sys/README.md
+++ b/bssl-bare-sys/README.md
@@ -25,18 +25,19 @@ chances are the list in `build.rs` is incomplete and must get amended.
 The `bssl-bare-sys` supports customizing the integration into
 freestanding/embedded-like environments.
 
-If the Cargo feature `target-integration` is enabled, `bssl-bare-sys`
-depends on a `bssl-bare-sys-target-integration` crate you're supposed
-to provide a substitute for, via e.g. Cargo's
+`bssl-bare-sys` depends on a `bssl-bare-sys-target-integration` crate
+that controls the BoringSSL build from its `build.rs` via the
+[`cargo::metadata=KEY=VALUE`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key)
+mechanism. A default stub is provided that links `libstdc++` for
+regular host (Linux) environments.
+
+For embedded or freestanding builds, you're supposed to provide a
+substitute for the `bssl-bare-sys-target-integration` crate via e.g.
+Cargo's
 [`[patch.'<URL>']`](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html)
 mechanism.
 
-This `bssl-bare-sys-target-integration` controls `bssl-bare-sys`'
-BoringSSL build from its `build.rs` via the
-[`cargo::metadata=KEY=VALUE`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key)
-mechanism.
-
-More specifically, the `bssl-bare-sys-target-integration` must have
+The `bssl-bare-sys-target-integration` must have
 `links = "bssl-bare-sys-target-integration"` in its `Cargo.toml` and
 may set any of the following `cargo::metadata` keys:
 
@@ -46,6 +47,9 @@ may set any of the following `cargo::metadata` keys:
 * `ASFLAGS` - Assembler flags for the BoringSSL build.
 * `BINDGEN_CFLAGS` - Flags to be passed to clang for the bindgen FFI
   generation.
+* `CMAKE_SYSTEM_NAME` - If set, passed to CMake as
+  `-DCMAKE_SYSTEM_NAME=<value>`. Use `Generic` for freestanding/embedded
+  targets.
 
 Furthermore, the `bssl-bare-sys-target-integration` may add any
 library to get linked for resolving BoringSSL's undefined references
@@ -53,3 +57,8 @@ via the usual
 [`cargo::rust-link-lib`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
 and specify library search paths by means of
 [`cargo::rust-link-search`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-search).
+
+The default `bssl-bare-sys-target-integration` stub links `libstdc++`
+(since BoringSSL contains C++ code). An embedded replacement would
+typically omit this and instead provide whatever C++ runtime (if any)
+is appropriate for the target environment.

--- a/bssl-bare-sys/build.rs
+++ b/bssl-bare-sys/build.rs
@@ -26,18 +26,12 @@ fn main() {
     let bssl_libcrypto = out_path.join("build").join("libcrypto.a");
     let _ = std::fs::remove_file(bssl_libcrypto);
 
-    let mut integration_cppflags = None;
-    let mut integration_cflags = None;
-    let mut integration_cxxflags = None;
-    let mut integration_asflags = None;
-    let mut integration_bindgen_cflags = None;
-    if cfg!(feature = "target-integration") {
-        integration_cppflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CPPFLAGS").ok();
-        integration_cflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CFLAGS").ok();
-        integration_cxxflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CXXFLAGS").ok();
-        integration_asflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_ASFLAGS").ok();
-        integration_bindgen_cflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_BINDGEN_CFLAGS").ok();
-    }
+    let integration_cppflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CPPFLAGS").ok();
+    let integration_cflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CFLAGS").ok();
+    let integration_cxxflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CXXFLAGS").ok();
+    let integration_asflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_ASFLAGS").ok();
+    let integration_bindgen_cflags = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_BINDGEN_CFLAGS").ok();
+    let integration_cmake_system_name = env::var("DEP_BSSL_BARE_SYS_TARGET_INTEGRATION_CMAKE_SYSTEM_NAME").ok();
 
     // Build openssl.
     let bssl_src_dir = "third-party/boringssl";
@@ -57,8 +51,8 @@ fn main() {
     if let Some(integration_asflags) = integration_asflags.as_ref() {
         cmake_config.asmflag(integration_asflags);
     }
-    if cfg!(feature = "target-integration") {
-        cmake_config.configure_arg("-DCMAKE_SYSTEM_NAME=Generic");
+    if let Some(cmake_system_name) = integration_cmake_system_name.as_ref() {
+        cmake_config.configure_arg(format!("-DCMAKE_SYSTEM_NAME={cmake_system_name}"));
     }
     cmake_config.build_target("crypto");
     let bssl_dst_path = cmake_config.build();

--- a/bssl-bare-sys/build.rs
+++ b/bssl-bare-sys/build.rs
@@ -139,6 +139,8 @@ fn main() {
         "sysconf",
         "time",
         "vsnprintf",
+        // C++ runtime symbols (libstdc++).
+        "_ZSt21__glibcxx_assert_failPKciS0_S0_",
     ] {
         cmd.arg("--redefine-sym")
             .arg(format!("{LINK_NAME_SYM_PREFIX}{sym}={sym}"));

--- a/bssl-bare-sys/src/lib.rs
+++ b/bssl-bare-sys/src/lib.rs
@@ -3,7 +3,6 @@
 
 // Explicit dependency against the bssl_bare_sys_target_integration crate, so that we'll include its
 // link-lib, if any, here.
-#[cfg(feature = "target-integration")]
 use cocoon_tpm_bssl_bare_sys_target_integration as _;
 
 include!(env!("BSSL_BARE_SYS_BINDGEN_WRAPPER_RS"));


### PR DESCRIPTION
This PR fixes the tests when using the BoringSSL backend and changes how target
integration setup is done slightly.

```
cargo test --features boringssl --workspace --exclude "*cli"
```

The problem is that BoringSSL makes use of C++, which leads to a linker error.
The simple fix could be to explicitly link to the systen c++ stdlib, if not building
for an embedded target by addind this:
```
diff --git a/bssl-bare-sys/build.rs b/bssl-bare-sys/build.rs
index 3b10f2f..0ad3472 100644
--- a/bssl-bare-sys/build.rs
+++ b/bssl-bare-sys/build.rs
@@ -204,6 +204,13 @@ fn main() {
         "cargo::rustc-link-search={}",
         bssl_build_path.as_os_str().to_os_string().into_string().unwrap()
     );
+    if !cfg!(feature = "target-integration") {
+        // BoringSSL contains C++ code. Without target-integration, assume a
+        // regular host environment and link libstdc++ directly. With
+        // target-integration enabled, the integration crate is responsible
+        // for providing whatever C++ runtime (if any) is appropriate.
+        println!("cargo::rustc-link-lib=stdc++");
+    }
     // Add the generated objects to the link.
     println!("cargo::rustc-link-lib=crypto");
 }
```

On the other hand we can get rid of the whole "target-integration" feature
and depend on the bssl-bare-sys-target-integration package unconditionally,
and have that in trun provide the default build configuration for the
non-embedded case using system default libraries. To build for embedded targets
the override via Cargo.toml can be used  to point to a specilaized instance
of it. This PR implements this change.
