### PR TITLE
utils-common: io_slices tests and fix

### DIFF
--- a/crypto/src/io_slices.rs
+++ b/crypto/src/io_slices.rs
@@ -174,8 +174,8 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a> for EmptyCryptoIoSlices {
         self.iter.total_len()
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        self.iter.all_aligned_to(alignment)
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        self.iter.all_lengths_multiple_of(alignment)
     }
 }
 

--- a/crypto/src/kdf/tcg_tpm2_kdf_a.rs
+++ b/crypto/src/kdf/tcg_tpm2_kdf_a.rs
@@ -185,8 +185,8 @@ impl<'a> Kdf for TcgTpm2KdfA<'a> {
         }
 
         // The block scratch buf will only be needed if any of the output slices'
-        // lengths doesn't align with the HMAC block length.
-        let block_scratch_buf_len = if !output.all_aligned_to(self.block_len)? {
+        // lengths isn't a multiple of the HMAC block length.
+        let block_scratch_buf_len = if !output.all_lengths_multiple_of(self.block_len)? {
             self.block_len
         } else {
             0

--- a/crypto/src/kdf/tcg_tpm2_kdf_e.rs
+++ b/crypto/src/kdf/tcg_tpm2_kdf_e.rs
@@ -173,8 +173,8 @@ impl<'a> Kdf for TcgTpm2KdfE<'a> {
         }
 
         // The block scratch buf will only be needed if any of the output slices'
-        // lengths doesn't align with the Hash block length.
-        let block_scratch_buf_len = if !output.all_aligned_to(self.block_len)? {
+        // lengths isn't a multiple of the Hash block length.
+        let block_scratch_buf_len = if !output.all_lengths_multiple_of(self.block_len)? {
             self.block_len
         } else {
             0

--- a/storage/src/fs/cocoonfs/transaction/auth_tree_data_blocks_update_states.rs
+++ b/storage/src/fs/cocoonfs/transaction/auth_tree_data_blocks_update_states.rs
@@ -4574,7 +4574,7 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
         Ok(())
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() && alignment <= (1usize << (self.allocation_block_size_128b_log2 as u32 + 7)) {
             // All Allocation Blocks are aligned. Check the head.
             Ok(self
@@ -4583,19 +4583,19 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
                 .map(|slice| slice.len() & (alignment - 1) == 0)
                 .unwrap_or(true))
         } else {
-            let mut all_aligned = true;
+            let mut all_multiple_of = true;
             if alignment.is_pow2() {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() & (alignment - 1) == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                    all_multiple_of
                 })?;
             } else {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() % alignment == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() % alignment == 0;
+                    all_multiple_of
                 })?;
             }
-            Ok(all_aligned)
+            Ok(all_multiple_of)
         }
     }
 }
@@ -4728,7 +4728,7 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
         Ok(())
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() && alignment <= (1usize << (self.allocation_block_size_128b_log2 as u32 + 7)) {
             // All Allocation Blocks are aligned. Check the head.
             Ok(self
@@ -4737,19 +4737,19 @@ impl<'a> io_slices::WalkableIoSlicesIter<'a>
                 .map(|slice| slice.len() & (alignment - 1) == 0)
                 .unwrap_or(true))
         } else {
-            let mut all_aligned = true;
+            let mut all_multiple_of = true;
             if alignment.is_pow2() {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() & (alignment - 1) == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                    all_multiple_of
                 })?;
             } else {
                 self.for_each(&mut |slice| {
-                    all_aligned &= slice.len() % alignment == 0;
-                    all_aligned
+                    all_multiple_of &= slice.len() % alignment == 0;
+                    all_multiple_of
                 })?;
             }
-            Ok(all_aligned)
+            Ok(all_multiple_of)
         }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2630,3 +2630,38 @@ impl<'a> PeekableIoSlicesIter<'a> for ZeroFilledIoSlices {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod walkable_io_slices_iter {
+        use super::*;
+
+        #[test]
+        fn empty_io_slices() {
+            let io_slice = EmptyIoSlices::default();
+            {
+                // total len
+                assert_eq!(io_slice.total_len().unwrap(), 0);
+            }
+
+            {
+                // for each
+                io_slice
+                    .for_each(&mut |_| {
+                        assert!(false, "This should never be called");
+                        true
+                    })
+                    .unwrap();
+            }
+
+            {
+                // all_lengths_multiple_of
+                assert!(io_slice.all_lengths_multiple_of(5).unwrap());
+                assert!(io_slice.all_lengths_multiple_of(1).unwrap());
+                assert!(io_slice.all_lengths_multiple_of(4223).unwrap());
+            }
+        }
+    }
+}

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2490,7 +2490,7 @@ where
             return Ok(());
         }
 
-        self.iter0.as_ref().map(|iter0| iter0.for_each(cb)).transpose()?;
+        self.iter1.as_ref().map(|iter1| iter1.for_each(cb)).transpose()?;
         Ok(())
     }
 

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2720,5 +2720,38 @@ mod tests {
                 }
             }
         }
+
+        #[test]
+        fn zero_filled_io_slices() {
+            const LEN: usize = ZeroFilledIoSlices::CHUNK_SIZE * 2 + 3;
+            let slice = ZeroFilledIoSlices::new(LEN);
+            {
+                // total len
+                assert_eq!(slice.total_len().unwrap(), LEN);
+            }
+
+            {
+                // for each
+                let expected1 = [0u8; ZeroFilledIoSlices::CHUNK_SIZE];
+                let expected2 = [0u8; 3];
+                let expected = [expected1.as_slice(), expected1.as_slice(), expected2.as_slice()];
+                let mut i = expected.iter();
+                slice
+                    .for_each(&mut |v| {
+                        assert_eq!(v, *i.next().unwrap());
+                        true
+                    })
+                    .unwrap();
+                assert!(i.next().is_none());
+            }
+
+            {
+                // all_lengths_multiple_of
+                assert!(slice.all_lengths_multiple_of(1).unwrap());
+                assert!(!slice.all_lengths_multiple_of(4).unwrap());
+                assert!(slice.all_lengths_multiple_of(5).unwrap());
+                assert!(!slice.all_lengths_multiple_of(17).unwrap());
+            }
+        }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -546,20 +546,20 @@ pub trait WalkableIoSlicesIter<'a>: IoSlicesIter<'a> {
     ///
     /// * [`BackendIteratorError`](IoSlicesIterCommon::BackendIteratorError) -
     ///   Error specific to the trait implementation.
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        let mut all_aligned = true;
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        let mut all_multiple_of = true;
         if alignment.is_pow2() {
             self.for_each(&mut |slice| {
-                all_aligned &= slice.len() & (alignment - 1) == 0;
-                all_aligned
+                all_multiple_of &= slice.len() & (alignment - 1) == 0;
+                all_multiple_of
             })?;
         } else {
             self.for_each(&mut |slice| {
-                all_aligned &= slice.len() % alignment == 0;
-                all_aligned
+                all_multiple_of &= slice.len() % alignment == 0;
+                all_multiple_of
             })?;
         }
-        Ok(all_aligned)
+        Ok(all_multiple_of)
     }
 }
 
@@ -1908,7 +1908,7 @@ impl<'a> WalkableIoSlicesIter<'a> for EmptyIoSlices {
         Ok(0)
     }
 
-    fn all_aligned_to(&self, _alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, _alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         Ok(true)
     }
 }
@@ -2025,8 +2025,8 @@ where
         self.iter.total_len().map_err(|e| (self.f)(e))
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        self.iter.all_aligned_to(alignment).map_err(|e| (self.f)(e))
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        self.iter.all_lengths_multiple_of(alignment).map_err(|e| (self.f)(e))
     }
 }
 
@@ -2138,8 +2138,8 @@ impl<'a, 'b: 'a, I: ?Sized + WalkableIoSlicesIter<'b>> WalkableIoSlicesIter<'a>
         (*self.iter).total_len()
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
-        (*self.iter).all_aligned_to(alignment)
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+        (*self.iter).all_lengths_multiple_of(alignment)
     }
 }
 
@@ -2499,17 +2499,17 @@ where
             + self.iter1.as_ref().map(|iter1| iter1.total_len()).unwrap_or(Ok(0))?)
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         Ok(self
             .iter0
             .as_ref()
-            .map(|iter0| iter0.all_aligned_to(alignment))
+            .map(|iter0| iter0.all_lengths_multiple_of(alignment))
             .transpose()?
             .unwrap_or(true)
             && self
                 .iter1
                 .as_ref()
-                .map(|iter1| iter1.all_aligned_to(alignment))
+                .map(|iter1| iter1.all_lengths_multiple_of(alignment))
                 .transpose()?
                 .unwrap_or(true))
     }
@@ -2612,7 +2612,7 @@ impl<'a> WalkableIoSlicesIter<'a> for ZeroFilledIoSlices {
         Ok(self.remaining)
     }
 
-    fn all_aligned_to(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
+    fn all_lengths_multiple_of(&self, alignment: usize) -> Result<bool, Self::BackendIteratorError> {
         if alignment.is_pow2() {
             Ok(self.remaining & (alignment - 1) == 0)
         } else {

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2817,5 +2817,37 @@ mod tests {
                 }
             }
         }
+
+        #[test]
+        fn singleton_io_slice_iter() {
+            let slice = [0u8, 1, 2, 3, 4, 5];
+            {
+                // total len
+                let io_slice = SingletonIoSlice::new(&slice);
+                assert_eq!(io_slice.total_len().unwrap(), 6);
+            }
+
+            {
+                // for each
+                let io_slice = SingletonIoSlice::new(&slice);
+                let slices = [slice.as_slice()];
+                let mut i = slices.iter();
+                io_slice
+                    .for_each(&mut |v| {
+                        assert_eq!(v, *i.next().unwrap());
+                        true
+                    })
+                    .unwrap();
+                assert!(i.next().is_none());
+            }
+
+            {
+                // all_lengths_multiple_of
+                let io_slice = SingletonIoSlice::new(&slice);
+                assert!(io_slice.all_lengths_multiple_of(6).unwrap());
+                assert!(io_slice.all_lengths_multiple_of(3).unwrap());
+                assert!(!io_slice.all_lengths_multiple_of(5).unwrap());
+            }
+        }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2849,5 +2849,62 @@ mod tests {
                 assert!(!io_slice.all_lengths_multiple_of(5).unwrap());
             }
         }
+
+        #[test]
+        fn generic_io_slices_iter() {
+            let prefix = [0u8, 1];
+            let buffer1 = [2u8, 3, 4, 5];
+            let buffer2 = [6u8, 7, 8, 9];
+            {
+                // without "head"
+                let iter = GenericIoSlicesIter::new(
+                    [Ok::<_, convert::Infallible>(buffer1.as_slice()), Ok(buffer2.as_slice())].into_iter(),
+                    None,
+                );
+
+                // total_len
+                assert_eq!(iter.total_len().unwrap(), buffer1.len() + buffer2.len());
+
+                // all_lengths_multiple_of
+                assert!(iter.all_lengths_multiple_of(4).unwrap());
+                assert!(!iter.all_lengths_multiple_of(5).unwrap());
+
+                // for_each
+                let slices = [buffer1.as_slice(), buffer2.as_slice()];
+                let mut i = slices.iter();
+                iter.for_each(&mut |v| {
+                    assert_eq!(v, *i.next().unwrap());
+                    true
+                })
+                .unwrap();
+                assert!(i.next().is_none());
+            }
+
+            {
+                // with "head"
+                let iter = GenericIoSlicesIter::new(
+                    [Ok::<_, convert::Infallible>(buffer1.as_slice()), Ok(buffer2.as_slice())].into_iter(),
+                    Some(prefix.as_slice()),
+                );
+
+                // total_len
+                assert_eq!(iter.total_len().unwrap(), buffer1.len() + buffer2.len() + prefix.len());
+
+                // all_lengths_multiple_of
+                assert!(iter.all_lengths_multiple_of(2).unwrap());
+                assert!(!iter.all_lengths_multiple_of(4).unwrap());
+                assert!(!iter.all_lengths_multiple_of(5).unwrap());
+
+                // for_each
+                let slices = [prefix.as_slice(), buffer1.as_slice(), buffer2.as_slice()];
+                let mut i = slices.iter();
+                iter.for_each(&mut |v| {
+                    assert_eq!(v, *i.next().unwrap());
+                    true
+                })
+                .unwrap();
+                assert!(i.next().is_none());
+            }
+        }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2753,5 +2753,69 @@ mod tests {
                 assert!(!slice.all_lengths_multiple_of(17).unwrap());
             }
         }
+
+        #[test]
+        fn io_slices_take_exact() {
+            let buffer1 = [0u8, 1];
+            let buffer2 = [2u8, 3, 4, 5, 6, 7, 8, 9];
+            let slices = [buffer1.as_slice(), buffer2.as_slice()];
+
+            {
+                // total len
+                let take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(5);
+
+                assert_eq!(take_exact.total_len().unwrap(), 5);
+            }
+
+            {
+                let mut take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(4);
+                assert_eq!(take_exact.next_slice(None).unwrap().unwrap(), buffer1);
+                assert_eq!(take_exact.next_slice(None).unwrap().unwrap(), &buffer2[0..2]);
+                assert!(take_exact.next_slice(None).unwrap().is_none());
+            }
+
+            {
+                // for each
+                let take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(4);
+                let all_slices = [buffer1.as_slice(), &buffer2[0..2]];
+                let mut i = all_slices.iter();
+
+                take_exact
+                    .for_each(&mut |v| {
+                        assert_eq!(v, *i.next().unwrap());
+                        true
+                    })
+                    .unwrap();
+                assert!(i.next().is_none());
+            }
+
+            {
+                // all_lengths_multiple_of
+                {
+                    let take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(4);
+                    // Lengths are 2 and 2
+                    assert!(take_exact.all_lengths_multiple_of(2).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(4).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(5).unwrap());
+                }
+                {
+                    let take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(3);
+                    // Lengths are 2 and 1
+                    assert!(take_exact.all_lengths_multiple_of(1).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(3).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(4).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(5).unwrap());
+                }
+                {
+                    let take_exact = BuffersSliceIoSlicesIter::new(&slices).take_exact(5);
+                    // Lengths are 2 and 3.
+                    assert!(take_exact.all_lengths_multiple_of(1).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(2).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(3).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(4).unwrap());
+                    assert!(!take_exact.all_lengths_multiple_of(5).unwrap());
+                }
+            }
+        }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2663,5 +2663,61 @@ mod tests {
                 assert!(io_slice.all_lengths_multiple_of(4223).unwrap());
             }
         }
+
+        #[test]
+        fn io_slices_iter_chain() {
+            let buffer1 = [0u8, 1, 2, 3, 4];
+            let slices1 = [buffer1.as_slice()];
+            let buffer2 = [5u8, 6, 7];
+            let slices2 = [buffer2.as_slice()];
+            let buffer3 = [5u8, 6, 7, 8, 9];
+            let slices3 = [buffer3.as_slice()];
+
+            {
+                // total len
+                let chain = IoSlicesIterChain::new(
+                    BuffersSliceIoSlicesIter::new(&slices1),
+                    BuffersSliceIoSlicesIter::new(&slices2),
+                );
+
+                assert_eq!(chain.total_len().unwrap(), buffer1.len() + buffer2.len());
+            }
+
+            {
+                // for each
+                let chain = IoSlicesIterChain::new(
+                    BuffersSliceIoSlicesIter::new(&slices1),
+                    BuffersSliceIoSlicesIter::new(&slices2),
+                );
+                let all_slices = [buffer1.as_slice(), buffer2.as_slice()];
+                let mut i = all_slices.iter();
+
+                chain
+                    .for_each(&mut |v| {
+                        assert_eq!(v, *i.next().unwrap());
+                        true
+                    })
+                    .unwrap();
+                assert!(i.next().is_none());
+            }
+
+            {
+                // all_lengths_multiple_of
+                {
+                    let chain_same_length = IoSlicesIterChain::new(
+                        BuffersSliceIoSlicesIter::new(&slices1),
+                        BuffersSliceIoSlicesIter::new(&slices3),
+                    );
+                    assert!(chain_same_length.all_lengths_multiple_of(5).unwrap());
+                }
+                {
+                    let chain_different_length = IoSlicesIterChain::new(
+                        BuffersSliceIoSlicesIter::new(&slices1),
+                        BuffersSliceIoSlicesIter::new(&slices2),
+                    );
+                    assert!(!chain_different_length.all_lengths_multiple_of(5).unwrap());
+                }
+            }
+        }
     }
 }

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2557,7 +2557,8 @@ pub struct ZeroFilledIoSlices {
 }
 
 impl ZeroFilledIoSlices {
-    const ZEROES_BUFFER: [u8; 16] = [0u8; 16];
+    pub const CHUNK_SIZE: usize = 16;
+    const ZEROES_BUFFER: [u8; Self::CHUNK_SIZE] = [0u8; Self::CHUNK_SIZE];
 
     /// Instantiate a `ZeroFilledIoSlices`.
     ///

--- a/utils-common/src/io_slices.rs
+++ b/utils-common/src/io_slices.rs
@@ -2906,5 +2906,31 @@ mod tests {
                 assert!(i.next().is_none());
             }
         }
+
+        #[test]
+        fn covariant_io_slices_iter() {
+            let buffer1 = [0u8, 1];
+            let buffer2 = [2u8, 3, 4, 5, 6, 7, 8, 9];
+            let slices = [buffer1.as_slice(), buffer2.as_slice()];
+
+            let mut iter1 = BuffersSliceIoSlicesIter::new(&slices);
+            let iter = iter1.as_ref();
+
+            // total len
+            assert_eq!(iter.total_len().unwrap(), buffer1.len() + buffer2.len());
+
+            // all_lengths_multiple_of
+            assert!(iter.all_lengths_multiple_of(2).unwrap());
+            assert!(!iter.all_lengths_multiple_of(4).unwrap());
+
+            // for_each
+            let mut i = slices.iter();
+            iter.for_each(&mut |v| {
+                assert_eq!(v, *i.next().unwrap());
+                true
+            })
+            .unwrap();
+            assert!(i.next().is_none());
+        }
     }
 }


### PR DESCRIPTION
Add some simple tests for the WalkableIoSlicesIter trait for many structs that implement it.
While they are quite trivial at times, they still cover a bug that is also fixed in this series.

I have to admit that I used AI and it found the bug, but the tests I wrote myself.

This PR is based on #16
