### PR TITLE
utils-common: index_permutation: Tests and fixes

### DIFF
--- a/utils-common/src/index_permutation.rs
+++ b/utils-common/src/index_permutation.rs
@@ -62,6 +62,10 @@ pub fn apply_and_invert_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [
         cycle_search_start = cycle_start + 1;
     }
 
+    // Verify that the permutation was valid: every entry must have been visited
+    // (handled) or be a genuine fixed point.
+    debug_assert!(index_perm.iter().enumerate().all(|(i, &v)| is_handled(v) || v == i));
+
     // Finally, clear the handle_offset markers
     for i in index_perm.iter_mut() {
         *i &= !handled_offset;
@@ -126,6 +130,10 @@ pub fn apply_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {
         }
         cycle_search_start = cycle_start + 1;
     }
+
+    // Verify that the permutation was valid: every entry must have been visited
+    // (handled) or be a genuine fixed point.
+    debug_assert!(index_perm.iter().enumerate().all(|(i, &v)| is_handled(v) || v == i));
 
     // Finally, clear the handle_offset markers
     for i in index_perm.iter_mut() {

--- a/utils-common/src/index_permutation.rs
+++ b/utils-common/src/index_permutation.rs
@@ -4,12 +4,18 @@
 
 //! Apply index permutations to slices.
 
-/// Apply an index permutation to a slice and invert the permuation in place.
+/// Apply an index permutation to a slice and invert the permutation in place.
+///
+/// This is equivalent to `result[i] = apply_to[index_perm[i]]` without requiring
+/// a separate intermediate buffer.
 ///
 /// # Arguments
 /// * `index_perm` - The index permutation to apply and subsequently invert in
-///   place. Its length must be less or equal than `usize::MAX / 2` for
-///   implementation reasons.
+///   place. After the function returns, `index_perm` will contain the inverse
+///   of the original permutation. Its length must be less or equal than
+///   `usize::MAX / 2` for implementation reasons.
+///   The permutation has to be valid: all indices up to `apply_to.len()` have to appear
+///   exactly once.
 /// * `apply_to` - The slice to apply the index permutation to. Its length must
 ///   match the one from `index_perm`.
 pub fn apply_and_invert_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {
@@ -64,13 +70,18 @@ pub fn apply_and_invert_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [
 
 /// Apply an index permutation to a slice.
 ///
+/// This is equivalent to `result[i] = apply_to[index_perm[i]]` without requiring
+/// a separate intermediate buffer.
+///
 /// # Arguments:
 ///
-/// * `index_perm` - The index permutation to apply. Even though its taken as a
+/// * `index_perm` - The index permutation to apply. It is taken as a
 ///   mutable reference (and is getting modified internally for tracking
-///   progress), its contents will return to the original state after the
+///   progress), its contents will be set to the identity permutation when the
 ///   function returns. Its length must be less or equal than `usize::MAX / 2`
 ///   for implementation reasons.
+///   The permutation has to be valid: all indices up to `apply_to.len()` have to appear
+///   exactly once.
 /// * `apply_to` - The slice to apply the index permutation to. Its length must
 ///   match the one from `index_perm`.
 pub fn apply_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {

--- a/utils-common/src/index_permutation.rs
+++ b/utils-common/src/index_permutation.rs
@@ -96,7 +96,7 @@ pub fn apply_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {
         loop {
             debug_assert!(!is_handled(index_perm[to]));
             let next_to = index_perm[to];
-            index_perm[to] = to | handled_offset;
+            index_perm[to] = next_to | handled_offset;
 
             if to != cycle_start {
                 // After the swap,

--- a/utils-common/src/index_permutation.rs
+++ b/utils-common/src/index_permutation.rs
@@ -4,12 +4,18 @@
 
 //! Apply index permutations to slices.
 
-/// Apply an index permutation to a slice and invert the permuation in place.
+/// Apply an index permutation to a slice and invert the permutation in place.
+///
+/// This is equivalent to `result[i] = apply_to[index_perm[i]]` without requiring
+/// a separate intermediate buffer.
 ///
 /// # Arguments
 /// * `index_perm` - The index permutation to apply and subsequently invert in
-///   place. Its length must be less or equal than `usize::MAX / 2` for
-///   implementation reasons.
+///   place. After the function returns, `index_perm` will contain the inverse
+///   of the original permutation. Its length must be less or equal than
+///   `usize::MAX / 2` for implementation reasons.
+///   The permutation has to be valid: all indices up to `apply_to.len()` have to appear
+///   exactly once.
 /// * `apply_to` - The slice to apply the index permutation to. Its length must
 ///   match the one from `index_perm`.
 pub fn apply_and_invert_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {
@@ -64,13 +70,18 @@ pub fn apply_and_invert_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [
 
 /// Apply an index permutation to a slice.
 ///
+/// This is equivalent to `result[i] = apply_to[index_perm[i]]` without requiring
+/// a separate intermediate buffer.
+///
 /// # Arguments:
 ///
-/// * `index_perm` - The index permutation to apply. Even though its taken as a
+/// * `index_perm` - The index permutation to apply. Even though it is taken as a
 ///   mutable reference (and is getting modified internally for tracking
 ///   progress), its contents will return to the original state after the
 ///   function returns. Its length must be less or equal than `usize::MAX / 2`
 ///   for implementation reasons.
+///   The permutation has to be valid: all indices up to `apply_to.len()` have to appear
+///   exactly once.
 /// * `apply_to` - The slice to apply the index permutation to. Its length must
 ///   match the one from `index_perm`.
 pub fn apply_index_perm<T>(index_perm: &mut [usize], apply_to: &mut [T]) {

--- a/utils-common/tests/index_permutation.rs
+++ b/utils-common/tests/index_permutation.rs
@@ -1,0 +1,147 @@
+mod index_permutation {
+    use cocoon_tpm_utils_common::index_permutation::*;
+    const IDENTITY_7: [usize; 7] = [0usize, 1, 2, 3, 4, 5, 6];
+    const DATA_7: [u8; 7] = [0u8, 1, 2, 3, 4, 5, 6];
+    mod apply_index_perm {
+        use super::*;
+
+        #[test]
+        fn identity() {
+            let mut d = DATA_7;
+            let mut p = IDENTITY_7;
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7);
+            assert_eq!(p, IDENTITY_7);
+        }
+
+        #[test]
+        fn shift() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 4, 5, 6, 0];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 4, 5, 6, 0], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn swap() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 3, 2, 4, 6, 5];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [0u8, 1, 3, 2, 4, 6, 5], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn swap_2() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 0, 2, 3, 4, 6, 5];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 0, 2, 3, 4, 6, 5], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn reverse() {
+            let mut d = DATA_7;
+            let mut p = [6usize, 5, 4, 3, 2, 1, 0];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [6u8, 5, 4, 3, 2, 1, 0], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn empty() {
+            let mut d: [u8; 0] = [];
+            let mut p: [usize; 0] = [];
+            apply_index_perm(&mut p, &mut d);
+        }
+
+        #[test]
+        fn single() {
+            let mut d = [42u8];
+            let mut p = [0usize];
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [42u8], "data array differs");
+            assert_eq!(p, [0usize], "index array differs");
+        }
+
+        #[test]
+        fn two_disjoint_cycles() {
+            // 3-cycle (0->1->2->0) and 2-cycle (3<->4), plus fixed points 5,6.
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 0, 4, 3, 5, 6];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 0, 4, 3, 5, 6], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn large_and_small_cycle() {
+            // 4-cycle (0->1->2->3->0) and 2-cycle (4<->5).
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 0, 5, 4, 6];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 0, 5, 4, 6], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+    }
+
+    mod apply_and_invert_index_perm {
+        use super::*;
+        #[test]
+        fn apply_and_invert_identity() {
+            let mut d = DATA_7;
+            let mut p = IDENTITY_7;
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7, "data array differs");
+            assert_eq!(p, IDENTITY_7, "inverse permutation differs");
+        }
+
+        #[test]
+        fn apply_and_invert_shift() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 4, 5, 6, 0];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 4, 5, 6, 0], "data array differs");
+            // Inverse of [1,2,3,4,5,6,0] is [6,0,1,2,3,4,5].
+            assert_eq!(p, [6usize, 0, 1, 2, 3, 4, 5], "inverse permutation differs");
+        }
+
+        #[test]
+        fn apply_and_invert_swap() {
+            let mut d = DATA_7;
+            let p_start = [1usize, 0, 2, 4, 3, 5, 6];
+            let mut p = p_start;
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 0, 2, 4, 3, 5, 6], "data array differs");
+            // Swaps are self-inverse.
+            assert_eq!(p, [1usize, 0, 2, 4, 3, 5, 6], "inverse permutation differs");
+        }
+
+        #[test]
+        fn roundtrip() {
+            // Apply a permutation, then apply its inverse to restore the original.
+            // Two 3-cycles: (0->1->2->0), (3->4->5->3), plus fixed point 6.
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 0, 4, 5, 3, 6];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 0, 4, 5, 3, 6], "data array differs");
+            // Verify the inverse permutation.
+            assert_eq!(p, [2usize, 0, 1, 5, 3, 4, 6], "inverse permutation differs");
+            // Applying the inverse should restore the original data.
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7, "roundtrip failed to restore data");
+        }
+    }
+}

--- a/utils-common/tests/index_permutation.rs
+++ b/utils-common/tests/index_permutation.rs
@@ -92,6 +92,26 @@ mod index_permutation {
             assert_eq!(d, [1u8, 2, 3, 0, 5, 4, 6], "data array differs");
             assert_eq!(p, IDENTITY_7, "index array differs");
         }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_0() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 2, 3, 4, 5, 1];
+
+            apply_index_perm(&mut p, &mut d);
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_1() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 1, 1, 1, 1, 1, 1];
+
+            apply_index_perm(&mut p, &mut d);
+        }
     }
 
     mod apply_and_invert_index_perm {
@@ -142,6 +162,26 @@ mod index_permutation {
             // Applying the inverse should restore the original data.
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, DATA_7, "roundtrip failed to restore data");
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_0() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 2, 3, 4, 5, 1];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_1() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 1, 1, 1, 1, 1, 1];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
         }
     }
 }

--- a/utils-common/tests/index_permutation.rs
+++ b/utils-common/tests/index_permutation.rs
@@ -22,41 +22,45 @@ mod index_permutation {
         #[test]
         fn shift() {
             let mut d = DATA_7;
-            let mut p = [1usize, 2, 3, 4, 5, 6, 0];
+            let p_orig = [1usize, 2, 3, 4, 5, 6, 0];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [1u8, 2, 3, 4, 5, 6, 0], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
 
         #[test]
         fn swap() {
             let mut d = DATA_7;
-            let mut p = [0usize, 1, 3, 2, 4, 6, 5];
+            let p_orig = [0usize, 1, 3, 2, 4, 6, 5];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [0u8, 1, 3, 2, 4, 6, 5], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
 
         #[test]
         fn swap_2() {
             let mut d = DATA_7;
-            let mut p = [1usize, 0, 2, 3, 4, 6, 5];
+            let p_orig = [1usize, 0, 2, 3, 4, 6, 5];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [1u8, 0, 2, 3, 4, 6, 5], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
 
         #[test]
         fn reverse() {
             let mut d = DATA_7;
-            let mut p = [6usize, 5, 4, 3, 2, 1, 0];
+            let p_orig = [6usize, 5, 4, 3, 2, 1, 0];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [6u8, 5, 4, 3, 2, 1, 0], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
 
         #[test]
@@ -79,22 +83,24 @@ mod index_permutation {
         fn two_disjoint_cycles() {
             // 3-cycle (0->1->2->0) and 2-cycle (3<->4), plus fixed points 5,6.
             let mut d = DATA_7;
-            let mut p = [1usize, 2, 0, 4, 3, 5, 6];
+            let p_orig = [1usize, 2, 0, 4, 3, 5, 6];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [1u8, 2, 0, 4, 3, 5, 6], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
 
         #[test]
         fn large_and_small_cycle() {
             // 4-cycle (0->1->2->3->0) and 2-cycle (4<->5).
             let mut d = DATA_7;
-            let mut p = [1usize, 2, 3, 0, 5, 4, 6];
+            let p_orig = [1usize, 2, 3, 0, 5, 4, 6];
+            let mut p = p_orig;
 
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, [1u8, 2, 3, 0, 5, 4, 6], "data array differs");
-            assert_eq!(p, IDENTITY_7, "index array differs");
+            assert_eq!(p, p_orig, "index array differs");
         }
     }
 

--- a/utils-common/tests/index_permutation.rs
+++ b/utils-common/tests/index_permutation.rs
@@ -102,6 +102,26 @@ mod index_permutation {
             assert_eq!(d, [1u8, 2, 3, 0, 5, 4, 6], "data array differs");
             assert_eq!(p, p_orig, "index array differs");
         }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_0() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 2, 3, 4, 5, 1];
+
+            apply_index_perm(&mut p, &mut d);
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_1() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 1, 1, 1, 1, 1, 1];
+
+            apply_index_perm(&mut p, &mut d);
+        }
     }
 
     mod apply_and_invert_index_perm {
@@ -152,6 +172,26 @@ mod index_permutation {
             // Applying the inverse should restore the original data.
             apply_index_perm(&mut p, &mut d);
             assert_eq!(d, DATA_7, "roundtrip failed to restore data");
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_0() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 2, 3, 4, 5, 1];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        #[should_panic]
+        fn assert_invalid_permutation_in_debug_1() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 1, 1, 1, 1, 1, 1];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
         }
     }
 }

--- a/utils-common/tests/index_permutation.rs
+++ b/utils-common/tests/index_permutation.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+mod index_permutation {
+    use cocoon_tpm_utils_common::index_permutation::*;
+    const IDENTITY_7: [usize; 7] = [0usize, 1, 2, 3, 4, 5, 6];
+    const DATA_7: [u8; 7] = [0u8, 1, 2, 3, 4, 5, 6];
+    mod apply_index_perm {
+        use super::*;
+
+        #[test]
+        fn identity() {
+            let mut d = DATA_7;
+            let mut p = IDENTITY_7;
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7);
+            assert_eq!(p, IDENTITY_7);
+        }
+
+        #[test]
+        fn shift() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 4, 5, 6, 0];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 4, 5, 6, 0], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn swap() {
+            let mut d = DATA_7;
+            let mut p = [0usize, 1, 3, 2, 4, 6, 5];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [0u8, 1, 3, 2, 4, 6, 5], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn swap_2() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 0, 2, 3, 4, 6, 5];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 0, 2, 3, 4, 6, 5], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn reverse() {
+            let mut d = DATA_7;
+            let mut p = [6usize, 5, 4, 3, 2, 1, 0];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [6u8, 5, 4, 3, 2, 1, 0], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn empty() {
+            let mut d: [u8; 0] = [];
+            let mut p: [usize; 0] = [];
+            apply_index_perm(&mut p, &mut d);
+        }
+
+        #[test]
+        fn single() {
+            let mut d = [42u8];
+            let mut p = [0usize];
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [42u8], "data array differs");
+            assert_eq!(p, [0usize], "index array differs");
+        }
+
+        #[test]
+        fn two_disjoint_cycles() {
+            // 3-cycle (0->1->2->0) and 2-cycle (3<->4), plus fixed points 5,6.
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 0, 4, 3, 5, 6];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 0, 4, 3, 5, 6], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+
+        #[test]
+        fn large_and_small_cycle() {
+            // 4-cycle (0->1->2->3->0) and 2-cycle (4<->5).
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 0, 5, 4, 6];
+
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 0, 5, 4, 6], "data array differs");
+            assert_eq!(p, IDENTITY_7, "index array differs");
+        }
+    }
+
+    mod apply_and_invert_index_perm {
+        use super::*;
+        #[test]
+        fn apply_and_invert_identity() {
+            let mut d = DATA_7;
+            let mut p = IDENTITY_7;
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7, "data array differs");
+            assert_eq!(p, IDENTITY_7, "inverse permutation differs");
+        }
+
+        #[test]
+        fn apply_and_invert_shift() {
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 3, 4, 5, 6, 0];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 3, 4, 5, 6, 0], "data array differs");
+            // Inverse of [1,2,3,4,5,6,0] is [6,0,1,2,3,4,5].
+            assert_eq!(p, [6usize, 0, 1, 2, 3, 4, 5], "inverse permutation differs");
+        }
+
+        #[test]
+        fn apply_and_invert_swap() {
+            let mut d = DATA_7;
+            let p_start = [1usize, 0, 2, 4, 3, 5, 6];
+            let mut p = p_start;
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 0, 2, 4, 3, 5, 6], "data array differs");
+            // Swaps are self-inverse.
+            assert_eq!(p, [1usize, 0, 2, 4, 3, 5, 6], "inverse permutation differs");
+        }
+
+        #[test]
+        fn roundtrip() {
+            // Apply a permutation, then apply its inverse to restore the original.
+            // Two 3-cycles: (0->1->2->0), (3->4->5->3), plus fixed point 6.
+            let mut d = DATA_7;
+            let mut p = [1usize, 2, 0, 4, 5, 3, 6];
+
+            apply_and_invert_index_perm(&mut p, &mut d);
+            assert_eq!(d, [1u8, 2, 0, 4, 5, 3, 6], "data array differs");
+            // Verify the inverse permutation.
+            assert_eq!(p, [2usize, 0, 1, 5, 3, 4, 6], "inverse permutation differs");
+            // Applying the inverse should restore the original data.
+            apply_index_perm(&mut p, &mut d);
+            assert_eq!(d, DATA_7, "roundtrip failed to restore data");
+        }
+    }
+}


### PR DESCRIPTION
Add tests for the index permutation functions and fix up the documentation
to match implementation.
Add debug assert to ensure permutation patterns are valid.

```diff
--- before2026-04-02 17:43:36.150422973 +0200
+++ after2026-04-02 17:43:18.813270176 +0200
@@ -4,10 +4,10 @@
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 bitmanip.rs                       199               199     0.00%          19                19     0.00%         124               124     0.00%           0                 0         -
 ct_cmp.rs                         267                 6    97.75%           6                 0   100.00%         115                 2    98.26%           0                 0         -
 fixed_vec.rs                      590                89    84.92%          50                12    76.00%         400                87    78.25%           0                 0         -
-index_permutation.rs              105               105     0.00%           6                 6     0.00%          71                71     0.00%           0                 0         -
+index_permutation.rs              105                 0   100.00%           6                 0   100.00%          71                 0   100.00%           0                 0         -
 io_slices.rs                     2453              1299    47.04%         192               164    14.58%        1359               878    35.39%           0                 0         -
 murmurhash3.rs                    107                28    73.83%           8                 0   100.00%          85                12    85.88%           0                 0         -
 xor.rs                            240                62    74.17%           3                 0   100.00%         108                34    68.52%           0                 0         -
 zeroize.rs                         85                85     0.00%          11                11     0.00%          60                60     0.00%           0                 0         -
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-TOTAL                            4102              1929    52.97%         299               216    27.76%        2354              1300    44.77%           0                 0         -
+TOTAL                            4102              1824    55.53%         299               210    29.77%        2354              1229    47.79%           0                 0         -
```
