### PR TITLE
utils-async: sync_types: Tests and fixes

### DIFF
--- a/utils-async/src/sync_types/generic_arc.rs
+++ b/utils-async/src/sync_types/generic_arc.rs
@@ -94,9 +94,7 @@ impl<T> Arc<T> {
         x.data.write(data);
         unsafe { Ok(Self::from_inner(Box::leak(x).into())) }
     }
-}
 
-impl<T> Arc<T> {
     /// Constructs an `Arc<T>` from a raw pointer.
     #[inline]
     pub unsafe fn from_raw(ptr: *const T) -> Self {
@@ -109,9 +107,7 @@ impl<T> Arc<T> {
             Self::from_ptr(arc_ptr)
         }
     }
-}
 
-impl<T> Arc<T> {
     /// Consumes the `Arc`, returning the wrapped pointer.
     #[inline]
     pub fn into_raw(this: Self) -> *const T {

--- a/utils-async/src/sync_types/generic_arc.rs
+++ b/utils-async/src/sync_types/generic_arc.rs
@@ -127,6 +127,10 @@ impl<T> Arc<T> {
 
     /// Creates a new [`Weak`] pointer to this allocation.
     pub fn downgrade(this: &Self) -> Weak<T> {
+        // Relaxed is sufficient here because this Arc exposes no `get_mut`,
+        // `is_unique`, or `new_cyclic` — there is no operation that needs to
+        // synchronize with weak-count changes. std::sync::Arc uses
+        // Acquire/Release in its downgrade to support those APIs.
         let mut cur = this.inner().weak.load(atomic::Ordering::Relaxed);
 
         loop {
@@ -344,6 +348,11 @@ impl<T> Weak<T> {
         // We use a CAS loop to increment the strong count instead of a
         // fetch_add as this function should never take the reference count
         // from zero to one.
+        //
+        // Relaxed is sufficient: the only transition that must synchronize
+        // with a strong-count change is the Release/Acquire pair in
+        // Arc::drop, which guards destruction. std::sync::Arc::upgrade uses
+        // Acquire to support get_mut/is_unique; we expose neither.
         if self
             .inner()
             .strong

--- a/utils-async/src/sync_types/generic_arc.rs
+++ b/utils-async/src/sync_types/generic_arc.rs
@@ -15,7 +15,7 @@
 // - no new_cyclic(), hence no uninitialized memory at birth, which allows for
 //   weaker memory ordering Weak::upgrade().
 
-//! Implementaion of [`GenericArc`].
+//! Implementation of [`GenericArc`].
 //!
 //! Based heavily on a trimmed version of Rust's core [`Arc`](alloc::sync::Arc).
 
@@ -60,7 +60,7 @@ impl<T: Sized> Arc<T> {
     }
 }
 
-/// Trimmed reimplementation of Rust's core [`Weak`](alloc::sync::Weak
+/// Trimmed reimplementation of Rust's core [`Weak`](alloc::sync::Weak).
 struct Weak<T> {
     ptr: NonNull<ArcInner<T>>,
 }
@@ -357,8 +357,7 @@ impl<T> Weak<T> {
         }
     }
 
-    /// Returns `None` when the pointer is dangling and there is no allocated
-    /// `ArcInner`, (i.e., when this `Weak` was created by `Weak::new`).
+    /// Gets the [`WeakInner`] pointer to access the reference counts.
     #[inline]
     fn inner(&self) -> WeakInner<'_> {
         let ptr = self.ptr.as_ptr();

--- a/utils-async/src/sync_types/mod.rs
+++ b/utils-async/src/sync_types/mod.rs
@@ -354,6 +354,7 @@ pub enum SyncRcPtrTryNewError {
 
 /// Error type returned by
 /// [`SyncRcPtrFactory::try_new_with()`](SyncRcPtrFactory::try_new_with).
+#[derive(Debug)]
 pub enum SyncRcPtrTryNewWithError<E> {
     /// Failure to allocate a new [`SyncRcPtr`].
     TryNewError(SyncRcPtrTryNewError),

--- a/utils-async/src/sync_types/mod.rs
+++ b/utils-async/src/sync_types/mod.rs
@@ -694,7 +694,7 @@ pub trait DerefInnerByTag<TAG> {
 /// Helper macro for implementing the [`DerefInnerByTag`] trait.
 #[macro_export]
 macro_rules! impl_deref_inner_by_tag {
-    ($field:ident, $field_type:path) => {
+    ($field:ident, $field_type:ty) => {
         type Output = $field_type;
 
         fn deref_inner(&self) -> &Self::Output {

--- a/utils-async/src/sync_types/mod.rs
+++ b/utils-async/src/sync_types/mod.rs
@@ -30,7 +30,7 @@
 //! for the reason of complying with the API's expectations -- after all, a lock
 //! on the containing `struct` grants exclusive access to the inner member as
 //! well and analogous for [`SyncRcPtr`]s. As atomic operations typically have
-//! some performace cost, it's desirable to eliminate the need for wrapping the
+//! some performance cost, it's desirable to eliminate the need for wrapping the
 //! member in an extra [`Lock`] or [`SyncRcPtr`]. For such scenarios the
 //! [`LockForInner`] and [`SyncRcPtrForInner`] implementations are provided.
 
@@ -141,7 +141,7 @@ where
 
 /// Locking guard obtained from [`LockForInner::lock()`](LockForInner::lock).
 ///
-/// Alternatively, an exising guard for the [`Lock`] wrapping the outer `OT` may
+/// Alternatively, an existing guard for the [`Lock`] wrapping the outer `OT` may
 /// get converted directly [to](Self::from_outer) and [back
 /// from](Self::into_outer) a `LockForInnerGuard` instance.
 pub struct LockForInnerGuard<'a, OT, OL, TAG>
@@ -252,7 +252,7 @@ pub trait SyncRcPtr<T: ?Sized>: Clone + ops::Deref<Target = T> + marker::Send + 
     /// Weak pointer type returned by [downgrade()](Self::downgrade).
     type WeakSyncRcPtr: WeakSyncRcPtr<T, Self>;
 
-    /// Pointer reference type returned by [ref()](Self::as_ref).
+    /// Pointer reference type returned by [as_ref()](Self::as_ref).
     ///
     /// Implementations generic over some `SyncRcPtr<T>` should prefer accepting
     /// a `SyncRcPtr<T>::SyncRcPtrRef` over `&SyncRcPtr<T>` whenever
@@ -308,7 +308,7 @@ pub trait SyncRcPtr<T: ?Sized>: Clone + ops::Deref<Target = T> + marker::Send + 
 ///
 /// A `WeakSyncRcPtr` instance does not hinder destruction of the original
 /// [`SyncRcPtr`]'s wrapped value. Note that this concerns only the
-/// [`drop()`](Drop::drop) -- the backing memory mat get deallocated only once
+/// [`drop()`](Drop::drop) -- the backing memory may get deallocated only once
 /// the last `WeakSyncRcPtr` is gone.
 pub trait WeakSyncRcPtr<T: ?Sized, P: SyncRcPtr<T>>: Clone + marker::Send + marker::Unpin {
     /// Convert a `WeakSyncRcPtr` back to a [`SyncRcPtr`].
@@ -348,7 +348,7 @@ pub trait WeakSyncRcPtr<T: ?Sized, P: SyncRcPtr<T>>: Clone + marker::Send + mark
 /// [`SyncRcPtrFactory::try_new_recoverable()`](SyncRcPtrFactory::try_new_recoverable).
 #[derive(Debug)]
 pub enum SyncRcPtrTryNewError {
-    /// Memory alocation failure.
+    /// Memory allocation failure.
     AllocationFailure,
 }
 
@@ -357,7 +357,7 @@ pub enum SyncRcPtrTryNewError {
 pub enum SyncRcPtrTryNewWithError<E> {
     /// Failure to allocate a new [`SyncRcPtr`].
     TryNewError(SyncRcPtrTryNewError),
-    /// The provided initalization callback returned an error indication.
+    /// The provided initialization callback returned an error indication.
     WithError(E),
 }
 
@@ -428,7 +428,7 @@ pub trait SyncRcPtrFactory {
     ///
     /// Furthermore, writing the initialization value returned by `new` directly
     /// into the destination memory may enable certain compiler
-    /// optimizations and safe copy over the stack.
+    /// optimizations and save a copy over the stack.
     fn try_new_with<T, R, E, N>(new: N) -> Result<(Self::SyncRcPtr<T>, R), SyncRcPtrTryNewWithError<E>>
     where
         T: marker::Send + marker::Sync,
@@ -464,7 +464,7 @@ pub trait SyncRcPtrFactory {
 /// Implementations generic over some [`SyncRcPtr<T>`](SyncRcPtr) should prefer
 /// accepting a `SyncRcPtrRef<T>` over a `&SyncRcPtr<T>` whenever possible.
 ///
-/// Doing so enables callers to potentially safe an atomic operation
+/// Doing so enables callers to potentially save an atomic operation
 /// just for creating an intermediate [`SyncRcPtr<T>`] in cases where that
 /// happens to be a derived [`SyncRcPtrForInner`], referring to some member of
 /// type `T` contained in an outer `struct OT` managed by a
@@ -488,14 +488,14 @@ pub trait SyncRcPtrRef<'a, T: ?Sized, P: 'a + SyncRcPtr<T>>: Clone + ops::Deref<
 
 /// [`WeakSyncRcPtr`] associated with a `Pin<SyncRcPtr<T>>`.
 ///
-/// An of [`SyncRcPtr`] for `Pin<SyncRcPtr<T>>` is provided and
+/// An implementation of [`SyncRcPtr`] for `Pin<SyncRcPtr<T>>` is provided and
 /// `PinnedWeakSyncRcPtr` is its associated [`WeakSyncRcPtr`] type returned by
 /// the implementation of
 /// [`Pin<SyncRcPtr<T>>::downgrade()`](SyncRcPtr::downgrade).
 ///
-/// Note that it is not possible to simply use `Pin<SyncRcPtr<T>::WeakSyncRcPtr`
+/// Note that it is not possible to simply use `Pin<SyncRcPtr<T>::WeakSyncRcPtr>`
 /// for that, as [`Pin`](pin::Pin) requires the wrapped pointer to be
-/// dereferencable.
+/// dereferenceable.
 pub struct PinnedWeakSyncRcPtr<T: ?Sized, P: SyncRcPtr<T>> {
     weak_ptr: P::WeakSyncRcPtr,
 }
@@ -735,7 +735,7 @@ macro_rules! impl_deref_inner_by_tag {
 /// typically a `struct` member.
 ///
 /// Users should not implement this trait by themselves, but use the
-/// [`impl_deref_mut inner_by_tag!()`](crate::impl_deref_mut inner_by_tag)
+/// [`impl_deref_mut_inner_by_tag!()`](crate::impl_deref_mut_inner_by_tag)
 /// macro.
 ///
 /// # Example:
@@ -781,7 +781,7 @@ macro_rules! impl_deref_mut_inner_by_tag {
 ///   reduces locality relative to the containing `struct`,
 /// * the atomic operations typically involved with cloning and destruction of
 ///   [`SyncRcPtr`] can be expensive -- the more instances there are and the
-///   more cachelines the different atomic reference counts are scattered over
+///   more cache lines the different atomic reference counts are scattered over
 ///   the worse it tends to get,
 /// * whereas the inner member's wrapping [`SyncRcPtr`] instance would be
 ///   completely superfluous from a lifetime management perspective, because the
@@ -1027,7 +1027,7 @@ where
 ///
 /// As outlined in the documentation to [`SyncRcPtrRef`], translating a
 /// [`SyncRcPtrRef`] for the outer containing `struct` to a
-/// `SyncRcPtrRefForInner` for the member is a zero cost operation, wheras going
+/// `SyncRcPtrRefForInner` for the member is a zero cost operation, whereas going
 /// from a [`SyncRcPtr`] for the outer `struct` to a [`SyncRcPtrForInner`] for
 /// the member is not.
 pub struct SyncRcPtrRefForInner<'a, OT, OP, OR, TAG>

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -4,4 +4,5 @@
 
 mod sync_types {
     mod deref_inner_by_tag;
+    mod generic_arc;
 }

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -5,4 +5,5 @@
 mod sync_types {
     mod deref_inner_by_tag;
     mod generic_arc;
+    mod generic_sync_rc_ptr_ref;
 }

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -8,4 +8,5 @@ mod sync_types {
     mod generic_sync_rc_ptr_ref;
     mod lock_for_inner;
     mod pinned_sync_rc_ptr;
+    mod sync_rc_ptr_for_inner;
 }

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+mod sync_types {
+    mod deref_inner_by_tag;
+}

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -6,4 +6,5 @@ mod sync_types {
     mod deref_inner_by_tag;
     mod generic_arc;
     mod generic_sync_rc_ptr_ref;
+    mod lock_for_inner;
 }

--- a/utils-async/tests/sync_types.rs
+++ b/utils-async/tests/sync_types.rs
@@ -7,4 +7,5 @@ mod sync_types {
     mod generic_arc;
     mod generic_sync_rc_ptr_ref;
     mod lock_for_inner;
+    mod pinned_sync_rc_ptr;
 }

--- a/utils-async/tests/sync_types/deref_inner_by_tag.rs
+++ b/utils-async/tests/sync_types/deref_inner_by_tag.rs
@@ -5,13 +5,9 @@
 use cocoon_tpm_utils_async::sync_types::{DerefInnerByTag, DerefMutInnerByTag};
 use cocoon_tpm_utils_async::{impl_deref_inner_by_tag, impl_deref_mut_inner_by_tag};
 
-// Note: field types are limited to path types (u32, u64, etc.) because
-// impl_deref_inner_by_tag! uses $field_type:path. Array types like [u8; 4],
-// reference types like &'static str, and tuple types like (u32, u64) are
-// rejected with "no rules expected this token in macro call".
 struct Outer {
     field_a: u32,
-    field_b: u64,
+    field_b: [u64; 1],
 }
 
 struct TagA;
@@ -26,7 +22,7 @@ impl DerefMutInnerByTag<TagA> for Outer {
 }
 
 impl DerefInnerByTag<TagB> for Outer {
-    impl_deref_inner_by_tag!(field_b, u64);
+    impl_deref_inner_by_tag!(field_b, [u64; 1]);
 }
 
 impl DerefMutInnerByTag<TagB> for Outer {
@@ -37,7 +33,7 @@ impl DerefMutInnerByTag<TagB> for Outer {
 fn deref_inner_field_a() {
     let outer = Outer {
         field_a: 42,
-        field_b: 100,
+        field_b: [100],
     };
     assert_eq!(*DerefInnerByTag::<TagA>::deref_inner(&outer), 42);
 }
@@ -46,26 +42,29 @@ fn deref_inner_field_a() {
 fn deref_inner_field_b() {
     let outer = Outer {
         field_a: 0,
-        field_b: 999,
+        field_b: [999],
     };
-    assert_eq!(*DerefInnerByTag::<TagB>::deref_inner(&outer), 999);
+    assert_eq!(*DerefInnerByTag::<TagB>::deref_inner(&outer), [999]);
 }
 
 #[test]
 fn deref_mut_inner() {
-    let mut outer = Outer { field_a: 0, field_b: 0 };
+    let mut outer = Outer {
+        field_a: 0,
+        field_b: [0],
+    };
     *DerefMutInnerByTag::<TagA>::deref_mut_inner(&mut outer) = 99;
     assert_eq!(outer.field_a, 99);
 
-    *DerefMutInnerByTag::<TagB>::deref_mut_inner(&mut outer) = 200;
-    assert_eq!(outer.field_b, 200);
+    *DerefMutInnerByTag::<TagB>::deref_mut_inner(&mut outer) = [200];
+    assert_eq!(outer.field_b, [200]);
 }
 
 #[test]
 fn to_inner_ptr_container_of_round_trip_a() {
     let outer = Outer {
         field_a: 42,
-        field_b: 0,
+        field_b: [0],
     };
     let outer_ptr: *const Outer = &outer;
     let inner_ptr = <Outer as DerefInnerByTag<TagA>>::to_inner_ptr(outer_ptr);
@@ -79,11 +78,11 @@ fn to_inner_ptr_container_of_round_trip_a() {
 fn to_inner_ptr_container_of_round_trip_b() {
     let outer = Outer {
         field_a: 0,
-        field_b: 12345,
+        field_b: [12345],
     };
     let outer_ptr: *const Outer = &outer;
     let inner_ptr = <Outer as DerefInnerByTag<TagB>>::to_inner_ptr(outer_ptr);
-    assert_eq!(unsafe { *inner_ptr }, 12345);
+    assert_eq!(unsafe { *inner_ptr }, [12345]);
 
     let recovered = unsafe { <Outer as DerefInnerByTag<TagB>>::container_of(inner_ptr) };
     assert_eq!(recovered, outer_ptr);

--- a/utils-async/tests/sync_types/deref_inner_by_tag.rs
+++ b/utils-async/tests/sync_types/deref_inner_by_tag.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::sync_types::{DerefInnerByTag, DerefMutInnerByTag};
+use cocoon_tpm_utils_async::{impl_deref_inner_by_tag, impl_deref_mut_inner_by_tag};
+
+// Note: field types are limited to path types (u32, u64, etc.) because
+// impl_deref_inner_by_tag! uses $field_type:path. Array types like [u8; 4],
+// reference types like &'static str, and tuple types like (u32, u64) are
+// rejected with "no rules expected this token in macro call".
+struct Outer {
+    field_a: u32,
+    field_b: u64,
+}
+
+struct TagA;
+struct TagB;
+
+impl DerefInnerByTag<TagA> for Outer {
+    impl_deref_inner_by_tag!(field_a, u32);
+}
+
+impl DerefMutInnerByTag<TagA> for Outer {
+    impl_deref_mut_inner_by_tag!(field_a);
+}
+
+impl DerefInnerByTag<TagB> for Outer {
+    impl_deref_inner_by_tag!(field_b, u64);
+}
+
+impl DerefMutInnerByTag<TagB> for Outer {
+    impl_deref_mut_inner_by_tag!(field_b);
+}
+
+#[test]
+fn deref_inner_field_a() {
+    let outer = Outer {
+        field_a: 42,
+        field_b: 100,
+    };
+    assert_eq!(*DerefInnerByTag::<TagA>::deref_inner(&outer), 42);
+}
+
+#[test]
+fn deref_inner_field_b() {
+    let outer = Outer {
+        field_a: 0,
+        field_b: 999,
+    };
+    assert_eq!(*DerefInnerByTag::<TagB>::deref_inner(&outer), 999);
+}
+
+#[test]
+fn deref_mut_inner() {
+    let mut outer = Outer { field_a: 0, field_b: 0 };
+    *DerefMutInnerByTag::<TagA>::deref_mut_inner(&mut outer) = 99;
+    assert_eq!(outer.field_a, 99);
+
+    *DerefMutInnerByTag::<TagB>::deref_mut_inner(&mut outer) = 200;
+    assert_eq!(outer.field_b, 200);
+}
+
+#[test]
+fn to_inner_ptr_container_of_round_trip_a() {
+    let outer = Outer {
+        field_a: 42,
+        field_b: 0,
+    };
+    let outer_ptr: *const Outer = &outer;
+    let inner_ptr = <Outer as DerefInnerByTag<TagA>>::to_inner_ptr(outer_ptr);
+    assert_eq!(unsafe { *inner_ptr }, 42);
+
+    let recovered = unsafe { <Outer as DerefInnerByTag<TagA>>::container_of(inner_ptr) };
+    assert_eq!(recovered, outer_ptr);
+}
+
+#[test]
+fn to_inner_ptr_container_of_round_trip_b() {
+    let outer = Outer {
+        field_a: 0,
+        field_b: 12345,
+    };
+    let outer_ptr: *const Outer = &outer;
+    let inner_ptr = <Outer as DerefInnerByTag<TagB>>::to_inner_ptr(outer_ptr);
+    assert_eq!(unsafe { *inner_ptr }, 12345);
+
+    let recovered = unsafe { <Outer as DerefInnerByTag<TagB>>::container_of(inner_ptr) };
+    assert_eq!(recovered, outer_ptr);
+}

--- a/utils-async/tests/sync_types/generic_arc.rs
+++ b/utils-async/tests/sync_types/generic_arc.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// Copyright The Rust Project Developers (see https://thanks.rust-lang.org)
 // Copyright 2026 Red Hat, LLC
 // Author: Oliver Steffen <osteffen@redhat.com>
 
@@ -6,7 +7,19 @@ use cocoon_tpm_utils_async::sync_types::{
     GenericArc, GenericArcFactory, GenericWeak, SyncRcPtr, SyncRcPtrFactory, SyncRcPtrTryNewWithError, WeakSyncRcPtr,
 };
 use core::ops::Deref;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+struct DropCanary(*mut AtomicUsize);
+
+// SAFETY: only used in single-threaded tests.
+unsafe impl Send for DropCanary {}
+unsafe impl Sync for DropCanary {}
+
+impl Drop for DropCanary {
+    fn drop(&mut self) {
+        unsafe { (*self.0).fetch_add(1, Ordering::SeqCst) };
+    }
+}
 
 #[test]
 fn try_new() {
@@ -170,4 +183,23 @@ fn drop_order_strong_then_weak() {
 
     drop(arc2);
     assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn drop_arc() {
+    let mut canary = AtomicUsize::new(0);
+    let arc = GenericArcFactory::try_new(DropCanary(&mut canary as *mut AtomicUsize)).unwrap();
+    drop(arc);
+    assert_eq!(canary.load(Ordering::Acquire), 1);
+}
+
+#[test]
+fn drop_arc_weak() {
+    let mut canary = AtomicUsize::new(0);
+    let arc = GenericArcFactory::try_new(DropCanary(&mut canary as *mut AtomicUsize)).unwrap();
+    let weak = arc.downgrade();
+    assert_eq!(canary.load(Ordering::Acquire), 0);
+    drop(arc);
+    assert_eq!(canary.load(Ordering::Acquire), 1);
+    drop(weak);
 }

--- a/utils-async/tests/sync_types/generic_arc.rs
+++ b/utils-async/tests/sync_types/generic_arc.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::sync_types::{
+    GenericArc, GenericArcFactory, GenericWeak, SyncRcPtr, SyncRcPtrFactory, SyncRcPtrTryNewWithError, WeakSyncRcPtr,
+};
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+#[test]
+fn try_new() {
+    let arc = GenericArcFactory::try_new(42u32).unwrap();
+    assert_eq!(*arc, 42);
+}
+
+#[test]
+fn clone_and_deref() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let arc2 = arc.clone();
+    assert_eq!(arc2.load(Ordering::Relaxed), 42);
+
+    arc.store(99, Ordering::Relaxed);
+    assert_eq!(arc2.load(Ordering::Relaxed), 99);
+
+    drop(arc2);
+    assert_eq!(arc.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn downgrade_upgrade() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let weak = arc.downgrade();
+
+    arc.store(99, Ordering::Relaxed);
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn upgrade_fails_after_all_strong_dropped() {
+    let arc = GenericArcFactory::try_new(42u32).unwrap();
+    let weak = arc.downgrade();
+
+    drop(arc);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn weak_clone() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let weak1 = arc.downgrade();
+    let weak2 = weak1.clone();
+
+    arc.store(99, Ordering::Relaxed);
+
+    let upgraded = weak2.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+
+    drop(weak1);
+    arc.store(200, Ordering::Relaxed);
+    let upgraded2 = weak2.upgrade().unwrap();
+    assert_eq!(upgraded2.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn into_raw_from_raw_round_trip() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let arc2 = arc.clone();
+
+    let raw = GenericArc::into_raw(arc);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 42);
+
+    arc2.store(99, Ordering::Relaxed);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 99);
+
+    let recovered = unsafe { GenericArc::<AtomicU32>::from_raw(raw) };
+    assert_eq!(recovered.load(Ordering::Relaxed), 99);
+
+    recovered.store(200, Ordering::Relaxed);
+    assert_eq!(arc2.load(Ordering::Relaxed), 200);
+
+    drop(arc2);
+    assert_eq!(recovered.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn weak_into_raw_from_raw_round_trip() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let weak = arc.downgrade();
+
+    let raw = GenericWeak::<AtomicU32>::into_raw(weak);
+
+    arc.store(99, Ordering::Relaxed);
+
+    let recovered = unsafe { GenericWeak::<AtomicU32>::from_raw(raw) };
+    let upgraded = recovered.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn try_new_recoverable_success() {
+    let result = GenericArcFactory::try_new_recoverable(42u32);
+    let arc = result.unwrap();
+    assert_eq!(*arc, 42);
+}
+
+#[test]
+fn try_new_with_success() {
+    let result = GenericArcFactory::try_new_with::<u32, &str, (), _>(|| Ok((42, "side-result")));
+    // SyncRcPtrTryNewWithError<E> does not derive Debug, so .unwrap() is unavailable.
+    let (arc, side) = match result {
+        Ok(v) => v,
+        Err(_) => panic!("expected Ok"),
+    };
+    assert_eq!(*arc, 42);
+    assert_eq!(side, "side-result");
+}
+
+#[test]
+fn try_new_with_callback_error() {
+    let result = GenericArcFactory::try_new_with::<u32, (), &str, _>(|| Err("callback failed"));
+    match result {
+        Err(SyncRcPtrTryNewWithError::WithError(msg)) => assert_eq!(msg, "callback failed"),
+        _ => panic!("expected WithError"),
+    }
+}
+
+#[test]
+fn deref_access() {
+    let arc = GenericArcFactory::try_new((1u32, 2u32)).unwrap();
+    assert_eq!(arc.deref().0, 1);
+    assert_eq!(arc.deref().1, 2);
+}
+
+#[test]
+fn multiple_weak_all_fail_after_strong_drop() {
+    let arc = GenericArcFactory::try_new(42u32).unwrap();
+    let weak1 = arc.downgrade();
+    let weak2 = arc.downgrade();
+    let weak3 = weak1.clone();
+
+    drop(arc);
+    assert!(weak1.upgrade().is_none());
+    assert!(weak2.upgrade().is_none());
+    assert!(weak3.upgrade().is_none());
+}
+
+#[test]
+fn drop_order_strong_then_weak() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let weak = arc.downgrade();
+    let arc2 = arc.clone();
+
+    arc.store(99, Ordering::Relaxed);
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+    drop(upgraded);
+
+    drop(arc);
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+    drop(upgraded);
+
+    arc2.store(200, Ordering::Relaxed);
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 200);
+    drop(upgraded);
+
+    drop(arc2);
+    assert!(weak.upgrade().is_none());
+}

--- a/utils-async/tests/sync_types/generic_arc.rs
+++ b/utils-async/tests/sync_types/generic_arc.rs
@@ -122,11 +122,7 @@ fn try_new_recoverable_success() {
 #[test]
 fn try_new_with_success() {
     let result = GenericArcFactory::try_new_with::<u32, &str, (), _>(|| Ok((42, "side-result")));
-    // SyncRcPtrTryNewWithError<E> does not derive Debug, so .unwrap() is unavailable.
-    let (arc, side) = match result {
-        Ok(v) => v,
-        Err(_) => panic!("expected Ok"),
-    };
+    let (arc, side) = result.unwrap();
     assert_eq!(*arc, 42);
     assert_eq!(side, "side-result");
 }

--- a/utils-async/tests/sync_types/generic_sync_rc_ptr_ref.rs
+++ b/utils-async/tests/sync_types/generic_sync_rc_ptr_ref.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::sync_types::{
+    GenericArc, GenericArcFactory, GenericSyncRcPtrRef, SyncRcPtr, SyncRcPtrFactory, SyncRcPtrRef, WeakSyncRcPtr,
+};
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+#[test]
+fn new_and_deref() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let ptr_ref = GenericSyncRcPtrRef::new(&arc);
+    assert_eq!(ptr_ref.load(Ordering::Relaxed), 42);
+}
+
+#[test]
+fn clone() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let ptr_ref = GenericSyncRcPtrRef::new(&arc);
+    let ptr_ref2 = ptr_ref.clone();
+
+    arc.store(99, Ordering::Relaxed);
+    assert_eq!(ptr_ref.load(Ordering::Relaxed), 99);
+    assert_eq!(ptr_ref2.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn make_clone() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let ptr_ref = GenericSyncRcPtrRef::new(&arc);
+    let cloned: GenericArc<AtomicU32> = ptr_ref.make_clone();
+
+    arc.store(99, Ordering::Relaxed);
+    assert_eq!(cloned.load(Ordering::Relaxed), 99);
+
+    drop(arc);
+    assert_eq!(cloned.load(Ordering::Relaxed), 99);
+
+    cloned.store(200, Ordering::Relaxed);
+    assert_eq!(cloned.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn make_weak_clone() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let ptr_ref = GenericSyncRcPtrRef::new(&arc);
+
+    let weak = ptr_ref.make_weak_clone();
+
+    arc.store(99, Ordering::Relaxed);
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn make_weak_clone_fails_after_strong_drop() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let weak = {
+        let ptr_ref = GenericSyncRcPtrRef::new(&arc);
+        ptr_ref.make_weak_clone()
+    };
+    drop(arc);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn as_ref_returns_generic_ref() {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(42)).unwrap();
+    let ptr_ref = arc.as_ref();
+
+    arc.store(99, Ordering::Relaxed);
+    assert_eq!(ptr_ref.deref().load(Ordering::Relaxed), 99);
+
+    let cloned = ptr_ref.make_clone();
+    assert_eq!(cloned.load(Ordering::Relaxed), 99);
+
+    arc.store(200, Ordering::Relaxed);
+    assert_eq!(cloned.load(Ordering::Relaxed), 200);
+}

--- a/utils-async/tests/sync_types/lock_for_inner.rs
+++ b/utils-async/tests/sync_types/lock_for_inner.rs
@@ -7,12 +7,9 @@ use cocoon_tpm_utils_async::test::TestNopLock;
 use cocoon_tpm_utils_async::{impl_deref_inner_by_tag, impl_deref_mut_inner_by_tag};
 use core::ops::{Deref, DerefMut};
 
-// Note: field types are limited to path types (u32, u64, etc.) because
-// impl_deref_inner_by_tag! uses $field_type:path. Array types like [u8; 4]
-// are rejected with "no rules expected this token in macro call".
 struct Outer {
     value: u32,
-    data: u64,
+    data: [u64; 1],
 }
 
 struct ValueTag;
@@ -27,7 +24,7 @@ impl DerefMutInnerByTag<ValueTag> for Outer {
 }
 
 impl DerefInnerByTag<DataTag> for Outer {
-    impl_deref_inner_by_tag!(data, u64);
+    impl_deref_inner_by_tag!(data, [u64; 1]);
 }
 
 impl DerefMutInnerByTag<DataTag> for Outer {
@@ -39,14 +36,14 @@ fn assert_value_lock(value: &impl Lock<u32>, expected: u32) {
     assert_eq!(*guard, expected);
 }
 
-fn assert_data_lock(data: &impl Lock<u64>, expected: u64) {
+fn assert_data_lock(data: &impl Lock<[u64; 1]>, expected: [u64; 1]) {
     let guard = data.lock();
     assert_eq!(*guard, expected);
 }
 
 #[test]
 fn lock_for_inner_read() {
-    let outer_lock = TestNopLock::from(Outer { value: 42, data: 100 });
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: [100] });
     let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
 
     assert_value_lock(&inner_lock, 42);
@@ -54,7 +51,7 @@ fn lock_for_inner_read() {
 
 #[test]
 fn lock_for_inner_write() {
-    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: [0] });
     let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
 
     {
@@ -68,18 +65,18 @@ fn lock_for_inner_write() {
 
 #[test]
 fn lock_for_inner_different_tags() {
-    let outer_lock = TestNopLock::from(Outer { value: 10, data: 200 });
+    let outer_lock = TestNopLock::from(Outer { value: 10, data: [200] });
 
     let value_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
     let data_lock: LockForInner<Outer, TestNopLock<Outer>, DataTag> = LockForInner::from_outer(&outer_lock);
 
     assert_value_lock(&value_lock, 10);
-    assert_data_lock(&data_lock, 200);
+    assert_data_lock(&data_lock, [200]);
 }
 
 #[test]
 fn lock_for_inner_guard_from_outer() {
-    let outer_lock = TestNopLock::from(Outer { value: 42, data: 0 });
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: [0] });
 
     let outer_guard = outer_lock.lock();
     let inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, ValueTag>::from_outer(outer_guard);
@@ -88,29 +85,29 @@ fn lock_for_inner_guard_from_outer() {
 
 #[test]
 fn lock_for_inner_guard_into_outer() {
-    let outer_lock = TestNopLock::from(Outer { value: 42, data: 100 });
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: [100] });
 
     let outer_guard = outer_lock.lock();
     let inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, ValueTag>::from_outer(outer_guard);
     let recovered_outer_guard = inner_guard.into_outer();
     assert_eq!(recovered_outer_guard.deref().value, 42);
-    assert_eq!(recovered_outer_guard.deref().data, 100);
+    assert_eq!(recovered_outer_guard.deref().data, [100]);
 }
 
 #[test]
 fn lock_for_inner_guard_deref_mut() {
-    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: [0] });
 
     let outer_guard = outer_lock.lock();
     let mut inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, DataTag>::from_outer(outer_guard);
-    *inner_guard.deref_mut() = 0xff;
+    *inner_guard.deref_mut() = [0xff];
     let recovered = inner_guard.into_outer();
-    assert_eq!(recovered.deref().data, 0xff);
+    assert_eq!(recovered.deref().data, [0xff]);
 }
 
 #[test]
 fn lock_for_inner_write_visible_through_outer() {
-    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: [0] });
 
     {
         let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
@@ -121,10 +118,10 @@ fn lock_for_inner_write_visible_through_outer() {
     {
         let inner_lock: LockForInner<Outer, TestNopLock<Outer>, DataTag> = LockForInner::from_outer(&outer_lock);
         let mut guard = inner_lock.lock();
-        *guard = 456;
+        *guard = [456];
     }
 
     let guard = outer_lock.lock();
     assert_eq!(guard.deref().value, 123);
-    assert_eq!(guard.deref().data, 456);
+    assert_eq!(guard.deref().data, [456]);
 }

--- a/utils-async/tests/sync_types/lock_for_inner.rs
+++ b/utils-async/tests/sync_types/lock_for_inner.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::sync_types::{DerefInnerByTag, DerefMutInnerByTag, Lock, LockForInner, LockForInnerGuard};
+use cocoon_tpm_utils_async::test::TestNopLock;
+use cocoon_tpm_utils_async::{impl_deref_inner_by_tag, impl_deref_mut_inner_by_tag};
+use core::ops::{Deref, DerefMut};
+
+// Note: field types are limited to path types (u32, u64, etc.) because
+// impl_deref_inner_by_tag! uses $field_type:path. Array types like [u8; 4]
+// are rejected with "no rules expected this token in macro call".
+struct Outer {
+    value: u32,
+    data: u64,
+}
+
+struct ValueTag;
+struct DataTag;
+
+impl DerefInnerByTag<ValueTag> for Outer {
+    impl_deref_inner_by_tag!(value, u32);
+}
+
+impl DerefMutInnerByTag<ValueTag> for Outer {
+    impl_deref_mut_inner_by_tag!(value);
+}
+
+impl DerefInnerByTag<DataTag> for Outer {
+    impl_deref_inner_by_tag!(data, u64);
+}
+
+impl DerefMutInnerByTag<DataTag> for Outer {
+    impl_deref_mut_inner_by_tag!(data);
+}
+
+fn assert_value_lock(value: &impl Lock<u32>, expected: u32) {
+    let guard = value.lock();
+    assert_eq!(*guard, expected);
+}
+
+fn assert_data_lock(data: &impl Lock<u64>, expected: u64) {
+    let guard = data.lock();
+    assert_eq!(*guard, expected);
+}
+
+#[test]
+fn lock_for_inner_read() {
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: 100 });
+    let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
+
+    assert_value_lock(&inner_lock, 42);
+}
+
+#[test]
+fn lock_for_inner_write() {
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+    let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
+
+    {
+        let mut guard = inner_lock.lock();
+        *guard = 99;
+    }
+
+    let guard = outer_lock.lock();
+    assert_eq!(guard.deref().value, 99);
+}
+
+#[test]
+fn lock_for_inner_different_tags() {
+    let outer_lock = TestNopLock::from(Outer { value: 10, data: 200 });
+
+    let value_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
+    let data_lock: LockForInner<Outer, TestNopLock<Outer>, DataTag> = LockForInner::from_outer(&outer_lock);
+
+    assert_value_lock(&value_lock, 10);
+    assert_data_lock(&data_lock, 200);
+}
+
+#[test]
+fn lock_for_inner_guard_from_outer() {
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: 0 });
+
+    let outer_guard = outer_lock.lock();
+    let inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, ValueTag>::from_outer(outer_guard);
+    assert_eq!(*inner_guard, 42);
+}
+
+#[test]
+fn lock_for_inner_guard_into_outer() {
+    let outer_lock = TestNopLock::from(Outer { value: 42, data: 100 });
+
+    let outer_guard = outer_lock.lock();
+    let inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, ValueTag>::from_outer(outer_guard);
+    let recovered_outer_guard = inner_guard.into_outer();
+    assert_eq!(recovered_outer_guard.deref().value, 42);
+    assert_eq!(recovered_outer_guard.deref().data, 100);
+}
+
+#[test]
+fn lock_for_inner_guard_deref_mut() {
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+
+    let outer_guard = outer_lock.lock();
+    let mut inner_guard = LockForInnerGuard::<Outer, TestNopLock<Outer>, DataTag>::from_outer(outer_guard);
+    *inner_guard.deref_mut() = 0xff;
+    let recovered = inner_guard.into_outer();
+    assert_eq!(recovered.deref().data, 0xff);
+}
+
+#[test]
+fn lock_for_inner_write_visible_through_outer() {
+    let outer_lock = TestNopLock::from(Outer { value: 0, data: 0 });
+
+    {
+        let inner_lock: LockForInner<Outer, TestNopLock<Outer>, ValueTag> = LockForInner::from_outer(&outer_lock);
+        let mut guard = inner_lock.lock();
+        *guard = 123;
+    }
+
+    {
+        let inner_lock: LockForInner<Outer, TestNopLock<Outer>, DataTag> = LockForInner::from_outer(&outer_lock);
+        let mut guard = inner_lock.lock();
+        *guard = 456;
+    }
+
+    let guard = outer_lock.lock();
+    assert_eq!(guard.deref().value, 123);
+    assert_eq!(guard.deref().data, 456);
+}

--- a/utils-async/tests/sync_types/pinned_sync_rc_ptr.rs
+++ b/utils-async/tests/sync_types/pinned_sync_rc_ptr.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::sync_types::{
+    GenericArc, GenericArcFactory, SyncRcPtr, SyncRcPtrFactory, SyncRcPtrRef, WeakSyncRcPtr,
+};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+type PinnedArc = Pin<GenericArc<AtomicU32>>;
+
+fn make_pinned_arc(val: u32) -> PinnedArc {
+    let arc = GenericArcFactory::try_new(AtomicU32::new(val)).unwrap();
+    Pin::new(arc)
+}
+
+#[test]
+fn pinned_deref() {
+    let pinned = make_pinned_arc(42);
+    assert_eq!(pinned.load(Ordering::Relaxed), 42);
+}
+
+#[test]
+fn pinned_clone() {
+    let pinned = make_pinned_arc(42);
+    let pinned2 = pinned.clone();
+    assert_eq!(pinned2.load(Ordering::Relaxed), 42);
+
+    pinned.store(99, Ordering::Relaxed);
+    assert_eq!(pinned2.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn pinned_downgrade_upgrade() {
+    let pinned = make_pinned_arc(42);
+    let weak = <PinnedArc as SyncRcPtr<AtomicU32>>::downgrade(&pinned);
+
+    pinned.store(99, Ordering::Relaxed);
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn pinned_weak_upgrade_fails_after_drop() {
+    let pinned = make_pinned_arc(42);
+    let weak = <PinnedArc as SyncRcPtr<AtomicU32>>::downgrade(&pinned);
+
+    drop(pinned);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn pinned_weak_clone() {
+    let pinned = make_pinned_arc(42);
+    let weak1 = <PinnedArc as SyncRcPtr<AtomicU32>>::downgrade(&pinned);
+    let weak2 = weak1.clone();
+
+    pinned.store(99, Ordering::Relaxed);
+
+    let upgraded1 = weak1.upgrade().unwrap();
+    let upgraded2 = weak2.upgrade().unwrap();
+    assert_eq!(upgraded1.load(Ordering::Relaxed), 99);
+    assert_eq!(upgraded2.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn pinned_into_raw_from_raw() {
+    let pinned = make_pinned_arc(42);
+    let pinned2 = pinned.clone();
+
+    let raw = <PinnedArc as SyncRcPtr<AtomicU32>>::into_raw(pinned);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 42);
+
+    pinned2.store(99, Ordering::Relaxed);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 99);
+
+    let recovered = unsafe { <PinnedArc as SyncRcPtr<AtomicU32>>::from_raw(raw) };
+    assert_eq!(recovered.load(Ordering::Relaxed), 99);
+
+    recovered.store(200, Ordering::Relaxed);
+    assert_eq!(pinned2.load(Ordering::Relaxed), 200);
+
+    drop(pinned2);
+}
+
+#[test]
+fn pinned_weak_into_raw_from_raw() {
+    let pinned = make_pinned_arc(42);
+    let weak = <PinnedArc as SyncRcPtr<AtomicU32>>::downgrade(&pinned);
+
+    type PinnedWeak = <PinnedArc as SyncRcPtr<AtomicU32>>::WeakSyncRcPtr;
+
+    let raw = PinnedWeak::into_raw(weak);
+
+    pinned.store(99, Ordering::Relaxed);
+
+    let recovered = unsafe { PinnedWeak::from_raw(raw) };
+    let upgraded = recovered.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn pinned_as_ref_make_clone() {
+    let pinned = make_pinned_arc(42);
+
+    pinned.store(99, Ordering::Relaxed);
+
+    let pinned_ref = <PinnedArc as SyncRcPtr<AtomicU32>>::as_ref(&pinned);
+    assert_eq!(pinned_ref.load(Ordering::Relaxed), 99);
+
+    let cloned = pinned_ref.make_clone();
+    assert_eq!(cloned.load(Ordering::Relaxed), 99);
+
+    pinned.store(200, Ordering::Relaxed);
+    assert_eq!(cloned.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn pinned_as_ref_make_weak_clone() {
+    let pinned = make_pinned_arc(42);
+
+    pinned.store(99, Ordering::Relaxed);
+
+    let pinned_ref = <PinnedArc as SyncRcPtr<AtomicU32>>::as_ref(&pinned);
+    let weak = pinned_ref.make_weak_clone();
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}

--- a/utils-async/tests/sync_types/sync_rc_ptr_for_inner.rs
+++ b/utils-async/tests/sync_types/sync_rc_ptr_for_inner.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Red Hat, LLC
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use cocoon_tpm_utils_async::impl_deref_inner_by_tag;
+use cocoon_tpm_utils_async::sync_types::{
+    DerefInnerByTag, GenericArc, GenericArcFactory, SyncRcPtr, SyncRcPtrFactory, SyncRcPtrForInner, SyncRcPtrRef,
+    WeakSyncRcPtr,
+};
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+// Note: field types are limited to path types (u32, u64, etc.) because
+// impl_deref_inner_by_tag! uses $field_type:path. Reference types like
+// &'static str are rejected with "no rules expected this token in macro call".
+struct Outer {
+    value: AtomicU32,
+    extra: u64,
+}
+
+struct ValueTag;
+struct ExtraTag;
+
+impl DerefInnerByTag<ValueTag> for Outer {
+    impl_deref_inner_by_tag!(value, AtomicU32);
+}
+
+impl DerefInnerByTag<ExtraTag> for Outer {
+    impl_deref_inner_by_tag!(extra, u64);
+}
+
+fn make_outer_arc() -> GenericArc<Outer> {
+    GenericArcFactory::try_new(Outer {
+        value: AtomicU32::new(42),
+        extra: 100,
+    })
+    .unwrap()
+}
+
+type InnerValuePtr = SyncRcPtrForInner<Outer, GenericArc<Outer>, ValueTag>;
+type InnerExtraPtr = SyncRcPtrForInner<Outer, GenericArc<Outer>, ExtraTag>;
+
+#[test]
+fn new_and_deref() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    assert_eq!(inner.load(Ordering::Relaxed), 42);
+}
+
+#[test]
+fn deref_different_tags() {
+    let arc = make_outer_arc();
+    let value_ptr: InnerValuePtr = SyncRcPtrForInner::new(arc.clone());
+    let extra_ptr: InnerExtraPtr = SyncRcPtrForInner::new(arc);
+    assert_eq!(value_ptr.load(Ordering::Relaxed), 42);
+    assert_eq!(*extra_ptr, 100);
+
+    value_ptr.store(99, Ordering::Relaxed);
+    assert_eq!(value_ptr.load(Ordering::Relaxed), 99);
+    assert_eq!(*extra_ptr, 100);
+}
+
+#[test]
+fn from_conversion() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = arc.into();
+    assert_eq!(inner.load(Ordering::Relaxed), 42);
+}
+
+#[test]
+fn clone_keeps_value_alive() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    let inner2 = inner.clone();
+
+    inner.store(99, Ordering::Relaxed);
+    assert_eq!(inner2.load(Ordering::Relaxed), 99);
+
+    drop(inner);
+    assert_eq!(inner2.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn get_container() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let container_ref = inner.get_container();
+    assert_eq!(container_ref.deref().value.load(Ordering::Relaxed), 99);
+    assert_eq!(container_ref.deref().extra, 100);
+}
+
+#[test]
+fn into_container() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let recovered_arc = inner.into_container();
+    assert_eq!(recovered_arc.value.load(Ordering::Relaxed), 99);
+    assert_eq!(recovered_arc.extra, 100);
+}
+
+#[test]
+fn downgrade_upgrade() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    let weak = inner.downgrade();
+    inner.store(99, Ordering::Relaxed);
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn inner_survives_outer_drop() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc.clone());
+
+    arc.value.store(99, Ordering::Relaxed);
+    assert_eq!(inner.load(Ordering::Relaxed), 99);
+
+    drop(arc);
+    assert_eq!(inner.load(Ordering::Relaxed), 99);
+
+    inner.store(200, Ordering::Relaxed);
+    assert_eq!(inner.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn weak_inner_survives_outer_drop() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc.clone());
+    let weak = inner.downgrade();
+
+    arc.value.store(99, Ordering::Relaxed);
+    drop(arc);
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn weak_inner_fails_after_all_strong_dropped() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc.clone());
+    let weak = inner.downgrade();
+
+    drop(arc);
+    drop(inner);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn weak_upgrade_fails_after_drop() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    let weak = inner.downgrade();
+
+    drop(inner);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn weak_clone() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    let weak1 = inner.downgrade();
+    let weak2 = weak1.clone();
+
+    inner.store(99, Ordering::Relaxed);
+
+    let upgraded1 = weak1.upgrade().unwrap();
+    let upgraded2 = weak2.upgrade().unwrap();
+    assert_eq!(upgraded1.load(Ordering::Relaxed), 99);
+    assert_eq!(upgraded2.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn into_raw_from_raw_round_trip() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    let inner2 = inner.clone();
+
+    let raw = InnerValuePtr::into_raw(inner);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 42);
+
+    inner2.store(99, Ordering::Relaxed);
+    assert_eq!(unsafe { &*raw }.load(Ordering::Relaxed), 99);
+
+    let recovered = unsafe { InnerValuePtr::from_raw(raw) };
+    assert_eq!(recovered.load(Ordering::Relaxed), 99);
+
+    recovered.store(200, Ordering::Relaxed);
+    assert_eq!(inner2.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn weak_into_raw_from_raw_round_trip() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+    let weak = inner.downgrade();
+
+    let raw = <InnerValuePtr as SyncRcPtr<AtomicU32>>::WeakSyncRcPtr::into_raw(weak);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let recovered = unsafe { <InnerValuePtr as SyncRcPtr<AtomicU32>>::WeakSyncRcPtr::from_raw(raw) };
+    let upgraded = recovered.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn sync_rc_ptr_ref_for_inner_make_clone() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let inner_ref = <InnerValuePtr as SyncRcPtr<AtomicU32>>::as_ref(&inner);
+    assert_eq!(inner_ref.load(Ordering::Relaxed), 99);
+
+    let cloned = inner_ref.make_clone();
+    assert_eq!(cloned.load(Ordering::Relaxed), 99);
+
+    inner.store(200, Ordering::Relaxed);
+    assert_eq!(cloned.load(Ordering::Relaxed), 200);
+}
+
+#[test]
+fn sync_rc_ptr_ref_for_inner_make_weak_clone() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let inner_ref = <InnerValuePtr as SyncRcPtr<AtomicU32>>::as_ref(&inner);
+    let weak = inner_ref.make_weak_clone();
+
+    let upgraded = weak.upgrade().unwrap();
+    assert_eq!(upgraded.load(Ordering::Relaxed), 99);
+}
+
+#[test]
+fn sync_rc_ptr_ref_for_inner_get_container() {
+    let arc = make_outer_arc();
+    let inner: InnerValuePtr = SyncRcPtrForInner::new(arc);
+
+    inner.store(99, Ordering::Relaxed);
+
+    let inner_ref = <InnerValuePtr as SyncRcPtr<AtomicU32>>::as_ref(&inner);
+    let container = inner_ref.get_container();
+    assert_eq!(container.deref().value.load(Ordering::Relaxed), 99);
+    assert_eq!(container.deref().extra, 100);
+}

--- a/utils-async/tests/sync_types/sync_rc_ptr_for_inner.rs
+++ b/utils-async/tests/sync_types/sync_rc_ptr_for_inner.rs
@@ -10,12 +10,9 @@ use cocoon_tpm_utils_async::sync_types::{
 use core::ops::Deref;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-// Note: field types are limited to path types (u32, u64, etc.) because
-// impl_deref_inner_by_tag! uses $field_type:path. Reference types like
-// &'static str are rejected with "no rules expected this token in macro call".
 struct Outer {
     value: AtomicU32,
-    extra: u64,
+    extra: [u64; 1],
 }
 
 struct ValueTag;
@@ -26,13 +23,13 @@ impl DerefInnerByTag<ValueTag> for Outer {
 }
 
 impl DerefInnerByTag<ExtraTag> for Outer {
-    impl_deref_inner_by_tag!(extra, u64);
+    impl_deref_inner_by_tag!(extra, [u64; 1]);
 }
 
 fn make_outer_arc() -> GenericArc<Outer> {
     GenericArcFactory::try_new(Outer {
         value: AtomicU32::new(42),
-        extra: 100,
+        extra: [100],
     })
     .unwrap()
 }
@@ -53,11 +50,11 @@ fn deref_different_tags() {
     let value_ptr: InnerValuePtr = SyncRcPtrForInner::new(arc.clone());
     let extra_ptr: InnerExtraPtr = SyncRcPtrForInner::new(arc);
     assert_eq!(value_ptr.load(Ordering::Relaxed), 42);
-    assert_eq!(*extra_ptr, 100);
+    assert_eq!(*extra_ptr, [100]);
 
     value_ptr.store(99, Ordering::Relaxed);
     assert_eq!(value_ptr.load(Ordering::Relaxed), 99);
-    assert_eq!(*extra_ptr, 100);
+    assert_eq!(*extra_ptr, [100]);
 }
 
 #[test]
@@ -89,7 +86,7 @@ fn get_container() {
 
     let container_ref = inner.get_container();
     assert_eq!(container_ref.deref().value.load(Ordering::Relaxed), 99);
-    assert_eq!(container_ref.deref().extra, 100);
+    assert_eq!(container_ref.deref().extra, [100]);
 }
 
 #[test]
@@ -101,7 +98,7 @@ fn into_container() {
 
     let recovered_arc = inner.into_container();
     assert_eq!(recovered_arc.value.load(Ordering::Relaxed), 99);
-    assert_eq!(recovered_arc.extra, 100);
+    assert_eq!(recovered_arc.extra, [100]);
 }
 
 #[test]
@@ -255,5 +252,5 @@ fn sync_rc_ptr_ref_for_inner_get_container() {
     let inner_ref = <InnerValuePtr as SyncRcPtr<AtomicU32>>::as_ref(&inner);
     let container = inner_ref.get_container();
     assert_eq!(container.deref().value.load(Ordering::Relaxed), 99);
-    assert_eq!(container.deref().extra, 100);
+    assert_eq!(container.deref().extra, [100]);
 }


### PR DESCRIPTION
Add basic tests for the sync-types, fix some typos and minor things.

```diff
--- before	2026-05-26 16:36:39.098441189 +0200
+++ after	2026-05-26 16:36:15.869265933 +0200
@@ -6,8 +6,8 @@
 asynchronous/future_queue.rs             628                74    88.22%          35                 7    80.00%         454                50    88.99%           0                 0         -
 asynchronous/rwlock.rs                   268               268     0.00%          55                55     0.00%         252               252     0.00%           0                 0         -
 asynchronous/semaphore.rs               1705               478    71.96%          88                33    62.50%        1069               320    70.07%           0                 0         -
-sync_types/generic_arc.rs                220                56    74.55%          38                 9    76.32%         178                39    78.09%           0                 0         -
-sync_types/mod.rs                        292               190    34.93%          54                32    40.74%         264               162    38.64%           0                 0         -
+sync_types/generic_arc.rs                220                 7    96.82%          38                 1    97.37%         178                 5    97.19%           0                 0         -
+sync_types/mod.rs                        292                19    93.49%          54                 3    94.44%         264                21    92.05%           0                 0         -
 test.rs                                  505               111    78.02%          40                13    67.50%         333                83    75.08%           0                 0         -
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-TOTAL                                   4203              1267    69.85%         356               158    55.62%        3013               982    67.41%           0                 0         -
+TOTAL                                   4203              1047    75.09%         356               121    66.01%        3013               807    73.22%           0                 0         -
```