### PR TITLE
cocoonfs: bump format version to 1

### DIFF
--- a/storage/src/fs/cocoonfs/auth_tree.rs
+++ b/storage/src/fs/cocoonfs/auth_tree.rs
@@ -1704,7 +1704,7 @@ impl AuthTreeConfig {
         h.update(
             io_slices::BuffersSliceIoSlicesIter::new(&[
                 b"COCOONFS".as_slice(),
-                0u8.to_le_bytes().as_slice(),
+                1u8.to_le_bytes().as_slice(),
                 image_layout.encode()?.as_slice(),
                 inode_index_entry_leaf_node_block_ptr.deref().as_slice(),
                 u64::from(image_size).to_le_bytes().as_slice(),

--- a/storage/src/fs/cocoonfs/cocoonfs-format.md
+++ b/storage/src/fs/cocoonfs/cocoonfs-format.md
@@ -516,7 +516,7 @@ The static image header starts at offset zero, its format is:
 +================================================+==================================================================+
 |8                                               |Magic string `'COCOONFS'` (without a terminating zero byte).      |
 +------------------------------------------------+------------------------------------------------------------------+
-|1                                               |The filesystem format version. Fixed to 0.                        |
+|1                                               |The filesystem format version. Fixed to 1.                        |
 +------------------------------------------------+------------------------------------------------------------------+
 |21                                              |The set of filesystem image layout parameters, c.f. further below.|
 +------------------------------------------------+------------------------------------------------------------------+
@@ -684,7 +684,7 @@ required for the actual filesystem creation and is of the following format:
 +================================+====================================================================================+
 |8                               |Magic string `'CCFSMKFS'` (without a terminating zero byte).                        |
 +--------------------------------+------------------------------------------------------------------------------------+
-|1                               |The filesystem creation info header format version. Fixed to 0.                     |
+|1                               |The filesystem creation info header format version. Fixed to 1.                     |
 +--------------------------------+------------------------------------------------------------------------------------+
 |21                              |The set of filesystem image layout parameters, encoded in the same                  |
 |                                |[format](#def-image-layout) as for the regular filesystem header's static part.     |
@@ -988,7 +988,7 @@ The root key is derived from the externally supplied key material by invoking `K
 * `label` - Constant `KEY_PURPOSE_DERIVATION`.
 * `context` - The concatenation of
    1. The magic string `'COCOONFS'`, without a terminating zero byte.
-   2. The image format version, fixed to 0, encoded as a single byte.
+   2. The image format version, fixed to 1, encoded as a single byte.
    3. [`kdf_hash_alg`](#def-image-layout) encoded as a 16 bit integer in big-endian format.
    4. [`auth_tree_root_hmac_hash_alg`](#def-image-layout) encoded as a 16 bit integer in big-endian format.
    5. [`auth_tree_node_hash_alg`](#def-image-layout) encoded as a 16 bit integer in big-endian format.
@@ -1196,7 +1196,7 @@ The image context digest is produced by forming a HMAC with same hash algorithm 
 over
 
 1. The magic `'COCOONFS'`, without a terminating zero byte.
-2. A single byte filesystem format version identifier of constant 0.
+2. A single byte filesystem format version identifier of constant 1.
 3. The [encoded image layout](#def-image-layout).
 4. The [encoded block pointer](#sec-enc-block-ptr) to the [inode index entry leaf
    node](#def-inode-index-entry-leaf-node), as found in the [mutable image header](#sec-mutable-image-header).

--- a/storage/src/fs/cocoonfs/image_header.rs
+++ b/storage/src/fs/cocoonfs/image_header.rs
@@ -91,7 +91,7 @@ impl MinStaticImageHeader {
         // The from_le_bytes() is a nop for an u8, but this mirrors the encoding part.
         let version =
             u8::from_le_bytes(*<&[u8; mem::size_of::<u8>()]>::try_from(version).map_err(|_| nvfs_err_internal!())?);
-        if version != 0 {
+        if version != 1 {
             return Err(NvFsError::from(FormatError::UnsupportedFormatVersion));
         }
 
@@ -247,7 +247,7 @@ impl StaticImageHeader {
             return Err(nvfs_err_internal!());
         }
 
-        let version = 0u8.to_le_bytes();
+        let version = 1u8.to_le_bytes();
         let mut version = io_slices::SingletonIoSlice::new(version.as_slice()).map_infallible_err();
         encoding_dst.copy_from_iter(&mut version)?;
         if !version.is_empty()? {
@@ -1574,7 +1574,7 @@ impl MinMkFsInfoHeader {
         // The from_le_bytes() is a nop for an u8, but this mirrors the encoding part.
         let version =
             u8::from_le_bytes(*<&[u8; mem::size_of::<u8>()]>::try_from(version).map_err(|_| nvfs_err_internal!())?);
-        if version != 0 {
+        if version != 1 {
             return Err(NvFsError::from(FormatError::UnsupportedFormatVersion));
         }
 
@@ -2019,7 +2019,7 @@ impl MkFsInfoHeader {
             return Err(nvfs_err_internal!());
         }
 
-        let version = 0u8.to_le_bytes();
+        let version = 1u8.to_le_bytes();
         let mut version = io_slices::SingletonIoSlice::new(version.as_slice()).map_infallible_err();
         encoding_dst.copy_from_iter(&mut version)?;
         if !version.is_empty()? {

--- a/storage/src/fs/cocoonfs/keys.rs
+++ b/storage/src/fs/cocoonfs/keys.rs
@@ -450,7 +450,7 @@ impl RootKey {
         // The context passed to KDFa for derivation of the root_key will be, in this
         // order,
         // - The magic 'COCOONFS', without a null terminator.
-        // - the image format version, as an u8, fixed to zero for now,
+        // - the image format version, as an u8, fixed to 1 for now,
         // - the kdf_hash_alg, as a u16,
         // - the auth_tree_root_hmac_hash_alg, as a u16,
         // - the auth_tree_node_hash_alg, as a u16,
@@ -470,7 +470,8 @@ impl RootKey {
         let buf = context_head.as_mut_slice();
         buf[..8].copy_from_slice(b"COCOONFS");
         let buf = &mut buf[8..];
-        let buf = tpm2_interface::marshal_u8(buf, 0).map_err(|_| nvfs_err_internal!())?;
+        buf[0] = 1;
+        let buf = &mut buf[1..];
         let buf = kdf_hash_alg.marshal(buf).map_err(|_| nvfs_err_internal!())?;
         let buf = auth_tree_root_hmac_hash_alg
             .marshal(buf)


### PR DESCRIPTION
There had been a number of incompatible format changes since the last release. Bump the CocoonFs format version from 0 to 1.